### PR TITLE
Fix wheel creation

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 
 [bdist_wheel]
 # Use this option if your package is pure-python
-universal =
+universal = 1
 
 [versioneer]
 VCS = git


### PR DESCRIPTION
Without this, attempting to build a wheel produces:
```bash
$ python setup.py bdist_wheel
/path/to/venv/lib/python2.7/site-packages/setuptools/dist.py:333: UserWarning: Normalizing '1.2.1.post.dev3' to '1.2.1.post0.dev3'
  normalized_version,
running bdist_wheel
error: invalid truth value ''
```