### PR TITLE
Added RecalculationNeeded Exception

### DIFF
--- a/cachier/mongo_core.py
+++ b/cachier/mongo_core.py
@@ -28,6 +28,8 @@ from .base_core import _BaseCore
 
 MONGO_SLEEP_DURATION_IN_SEC = 1
 
+class RecalculationNeeded(Exception):
+    pass
 
 class _MongoCore(_BaseCore):
 
@@ -126,6 +128,8 @@ class _MongoCore(_BaseCore):
         while True:
             time.sleep(MONGO_SLEEP_DURATION_IN_SEC)
             key, entry = self.get_entry_by_key(key)
+            if entry is None:
+                raise RecalculationNeeded()
             if entry is not None and not entry['being_calculated']:
                 return entry['value']
 


### PR DESCRIPTION
Hello,

in this scenario we cachier is getting a deadlock:
-  cache backend: mongodb
-  process_1 is calling an expensive function
-  process_2 is calling an expensive function
-  process_3 is calling clear_cache

Then there is a deadlock.  I guess in a multi-process environment it doesn't make sense to use the pickle_code. So that fix is only applied on the mongo core.

This can happen quite often, at least in my environment. For some reason, the _expensive function_ doesn't finalize or needs too long. Therefore process_3 is responsible to clear the cache. 
