### PR TITLE
Change args value to string

### DIFF
--- a/cachier/pickle_core.py
+++ b/cachier/pickle_core.py
@@ -130,8 +130,8 @@ class _PickleCore(_BaseCore):
             return key, self._get_cache().get(key, None)
 
     def get_entry(self, args, kwds):
+        args = tuple([str(arg) for arg in args])
         key = args + tuple(sorted(kwds.items()))
-        # print('key type={}, key={}'.format(type(key), key))
         return self.get_entry_by_key(key)
 
     def set_entry(self, key, func_res):


### PR DESCRIPTION
I tried to pass numpy.array or pandas.DataFrame to the parameters, but it doesn't work because they are used as dict hash. For making it work temporarily, I'd like to suggest convert args into string.

Please give me your opinion to handle these problem.