### PR TITLE
Avoid using pip internal function to make cachier work on pip>=10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,11 @@ matrix:
 before_install:
   # coverage submission packages
   - pip install -U pip
+  - pip install -U pytest
   - pip install codecov
   - pip install pymongo
 install:
-  - if [ "$TRAVIS_PYTHON_VERSION" == "2.7" ]; then pip install pytest coverage pytest-cov .; else pip install ".[test]"; fi
+  - if [ "$TRAVIS_PYTHON_VERSION" == "2.7" ]; then pip install coverage pytest-cov .; else pip install ".[test]"; fi
 script: python -m pytest --cov=cachier
 # submit coverage
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ matrix:
       sudo: true
 before_install:
   # coverage submission packages
+  - pip install -U pip
   - pip install codecov
   - pip install pymongo
 install:

--- a/cachier/core.py
+++ b/cachier/core.py
@@ -16,18 +16,7 @@ import os
 from functools import wraps
 
 import datetime
-try:  # for asynchronous file uploads
-    from concurrent.futures import ThreadPoolExecutor
-except ImportError:  # we're in python 2.x
-    import pip
-    PACKAGES = [
-        package.project_name
-        for package
-        in pip.get_installed_distributions()
-    ]
-    if 'futures' not in PACKAGES:
-        pip.main(['install', 'futures'])
-    from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor
 
 from .pickle_core import _PickleCore
 from .mongo_core import _MongoCore, RecalculationNeeded

--- a/setup.py
+++ b/setup.py
@@ -38,10 +38,11 @@ setup(
         cachier=cachier.scripts.cli:cli
     ''',
     install_requires=[
-        'watchdog', 'portalocker'
+        'watchdog', 'portalocker',
     ],
     extras_require={
-        'test': TEST_REQUIRES
+        'test': TEST_REQUIRES,
+        ':python_version == "2.7"': ['futures'],
     },
     platforms=['linux', 'osx', 'windows'],
     keywords=['cache', 'persistence', 'mongo', 'memoization', 'decorator'],


### PR DESCRIPTION
cachier won't work on recent pip version due to the internal function has been moved.
```
$ pip install -U pip
$ pip install cachier
$ python -c "import cachier"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/private/tmp/venv/lib/python2.7/site-packages/cachier/__init__.py", line 1, in <module>
    from .core import cachier
  File "/private/tmp/venv/lib/python2.7/site-packages/cachier/core.py", line 26, in <module>
    in pip.get_installed_distributions()
AttributeError: 'module' object has no attribute 'get_installed_distributions'
```

This PR will install `futures` for python2.7 from setup.py