### PR TITLE
Changed isAlive to is_alive

### DIFF
--- a/cachier/pickle_core.py
+++ b/cachier/pickle_core.py
@@ -201,7 +201,7 @@ class _PickleCore(_BaseCore):
         )
         observer.start()
         observer.join(timeout=1.0)
-        if observer.isAlive():
+        if observer.is_alive():
             # print('Timedout waiting. Starting again...')
             return self.wait_on_entry_calc(key)
         # print("Returned value: {}".format(event_handler.value))


### PR DESCRIPTION
Hi there!

Fantastic work on this package! It's such an amazingly simple way of avoiding to overload APIs with unnecessary requests!

I noticed however that there was a deprecation warning popping up sometimes, namely:
`
 "cachier\pickle_core.py:204: DeprecationWarning: isAlive() is deprecated, use is_alive() instead
  if observer.isAlive():"
`

As far as my quick searches seem to tell me, the isAlive is still a remainder from the Python 2 support, which has been dropped in cachier from version 1.2.8, so I assume this can be updated :)