### PR TITLE
Change `wait_on_entry_calc` to use while loop instead of recursion

### DIFF
--- a/cachier/pickle_core.py
+++ b/cachier/pickle_core.py
@@ -200,10 +200,12 @@ class _PickleCore(_BaseCore):
             event_handler, path=self.expended_cache_dir, recursive=True
         )
         observer.start()
-        observer.join(timeout=1.0)
-        if observer.is_alive():
+        while observer.is_alive():
+            observer.join(timeout=1.0)
+        # observer.join(timeout=1.0)
+        # if observer.is_alive():
             # print('Timedout waiting. Starting again...')
-            return self.wait_on_entry_calc(key)
+            # return self.wait_on_entry_calc(key)
         # print("Returned value: {}".format(event_handler.value))
         return event_handler.value
 


### PR DESCRIPTION
@shaypal5 I'm submitting this PR to hopefully make cachier a _bit_ more usable with long-running functions.

I had noticed that the recursion pattern in `wait_on_entry_calc` was causing the issues I was seeing in #24. I changed the implementation here, and ran a few test cases on a project I was working on.

For short-running functions, nothing breaks. The cache gets loaded correctly, and the function executes correctly. For functions that are already cached, I made sure to use `overwrite_cache=True` to force overwriting of the cache. ~~For long-running functions, the function just keeps on executing nicely until it finishes up and pickles down the result.~~ I take this back - I am still measuring to see whether this code works properly.

UPDATE 3:52 PM: I think this is working as expected. It's a long-running database query that we cache locally. I can see in pgadmin that the data are being pulled.

If you see that this is an erroneous PR, please let me know. Otherwise, please go to town with your critiques, and let me know what you'd like fixed up, I am happy to continue working on the PR till you're satisfied :smile:.