### PR TITLE
Calculation timeout for MongoDB Backend

### DIFF
--- a/cachier/core.py
+++ b/cachier/core.py
@@ -80,6 +80,7 @@ def cachier(
     mongetter=None,
     cache_dir=None,
     hash_params=None,
+    wait_for_calc_timeout=0
 ):
     """A persistent, stale-free memoization decorator.
 
@@ -118,6 +119,12 @@ def cachier(
         and returns a hash key for them. This parameter can be used to enable
         the use of cachier with functions that get arguments that are not
         automatically hashable by Python.
+    wait_for_calc_timeout: int, optional, for MongoDB only
+        The maximum time to wait for an ongoing calculation. When a
+        process started to calculate the value setting being_calculated to 
+        True, any process trying to read the same entry will wait a maximum of 
+        seconds specified in this parameter. 0 means wait forever.
+        Once the timeout expires the calculation will be triggered.
     """
     # print('Inside the wrapper maker')
     # print('mongetter={}'.format(mongetter))
@@ -125,7 +132,7 @@ def cachier(
     # print('next_time={}'.format(next_time))
 
     if mongetter:
-        core = _MongoCore(mongetter, stale_after, next_time)
+        core = _MongoCore(mongetter, stale_after, next_time, wait_for_calc_timeout)
     else:
         core = _PickleCore(  # pylint: disable=R0204
             stale_after=stale_after,

--- a/cachier/mongo_core.py
+++ b/cachier/mongo_core.py
@@ -134,7 +134,6 @@ class _MongoCore(_BaseCore):
     def wait_on_entry_calc(self, key):
         time_spent = 0
         while True:
-            print("Waiting for Mongo cache...")
             time.sleep(MONGO_SLEEP_DURATION_IN_SEC)
             time_spent += MONGO_SLEEP_DURATION_IN_SEC
             key, entry = self.get_entry_by_key(key)
@@ -144,9 +143,7 @@ class _MongoCore(_BaseCore):
             if not entry['being_calculated']:
                 return entry['value']
 
-            print("Got an entry. It is being calculated. Do we wait?", time_spent, self.wait_for_calc_timeout, time_spent >= self.wait_for_calc_timeout)
             if self.wait_for_calc_timeout > 0 and time_spent >= self.wait_for_calc_timeout:
-                print("Tired of waiting. RecalculationNeeded.", time_spent, self.wait_for_calc_timeout, time_spent >= self.wait_for_calc_timeout)
                 raise RecalculationNeeded()
 
 

--- a/cachier/mongo_core.py
+++ b/cachier/mongo_core.py
@@ -135,7 +135,7 @@ class _MongoCore(_BaseCore):
         time_spent = 0
         while True:
             time.sleep(MONGO_SLEEP_DURATION_IN_SEC)
-            time_spent += 1
+            time_spent += MONGO_SLEEP_DURATION_IN_SEC
             key, entry = self.get_entry_by_key(key)
             if entry is None:
                 raise RecalculationNeeded()

--- a/cachier/mongo_core.py
+++ b/cachier/mongo_core.py
@@ -134,18 +134,19 @@ class _MongoCore(_BaseCore):
     def wait_on_entry_calc(self, key):
         time_spent = 0
         while True:
+            print("Waiting for Mongo cache...")
             time.sleep(MONGO_SLEEP_DURATION_IN_SEC)
             time_spent += MONGO_SLEEP_DURATION_IN_SEC
             key, entry = self.get_entry_by_key(key)
             if entry is None:
                 raise RecalculationNeeded()
 
-            if entry is not None:
-                if not entry['being_calculated']:
-                    return entry['value']
+            if not entry['being_calculated']:
+                return entry['value']
 
-                if self.wait_for_calc_timeout > 0 and time_spent >= self.wait_for_calc_timeout:
-                    raise RecalculationNeeded()
+            if self.wait_for_calc_timeout > 0 and time_spent >= self.wait_for_calc_timeout:
+                print("Got an entry. Is not valid. Force recomputation.", time_spent, self.wait_for_calc_timeout, time_spent >= self.wait_for_calc_timeout)
+                raise RecalculationNeeded()
 
 
     def clear_cache(self):

--- a/cachier/mongo_core.py
+++ b/cachier/mongo_core.py
@@ -144,8 +144,9 @@ class _MongoCore(_BaseCore):
             if not entry['being_calculated']:
                 return entry['value']
 
+            print("Got an entry. It is being calculated. Do we wait?", time_spent, self.wait_for_calc_timeout, time_spent >= self.wait_for_calc_timeout)
             if self.wait_for_calc_timeout > 0 and time_spent >= self.wait_for_calc_timeout:
-                print("Got an entry. Is not valid. Force recomputation.", time_spent, self.wait_for_calc_timeout, time_spent >= self.wait_for_calc_timeout)
+                print("Tired of waiting. RecalculationNeeded.", time_spent, self.wait_for_calc_timeout, time_spent >= self.wait_for_calc_timeout)
                 raise RecalculationNeeded()
 
 

--- a/tests/test_mongo_core.py
+++ b/tests/test_mongo_core.py
@@ -206,7 +206,7 @@ def test_mongo_wait_for_calc_timeout_slow():
     res2 = res_queue.get()
     assert res1 != res2 # Timeout kicked in.  Two calls were done
     res3 = _wait_for_calc_timeout_mongo_slow(1, 2)
-    assert res2 == res3 # The cached value is returned
+    assert res2 == res3 or res1 == res3 # One of the cached values is returned
 
 
 class _BadMongoCollection:

--- a/tests/test_mongo_core.py
+++ b/tests/test_mongo_core.py
@@ -153,6 +153,7 @@ def _calls_wait_for_calc_timeout_mongo_fast(res_queue):
 
 
 def test_mongo_wait_for_calc_timeout_ok():
+    """ Testing calls that avoid timeouts store the values in cache. """
     _wait_for_calc_timeout_mongo_fast.clear_cache()
     val1 = _wait_for_calc_timeout_mongo_fast(1, 2)
     val2 = _wait_for_calc_timeout_mongo_fast(1, 2)
@@ -187,7 +188,7 @@ def _calls_wait_for_calc_timeout_mongo_slow(res_queue):
 
 
 def test_mongo_wait_for_calc_timeout_slow():
-    """Testing for calls that time out are performed again."""
+    """Testing for calls timing out to be performed twice when needed."""
     _wait_for_calc_timeout_mongo_slow.clear_cache()
     res_queue = queue.Queue()
     thread1 = threading.Thread(

--- a/tests/test_mongo_core.py
+++ b/tests/test_mongo_core.py
@@ -177,12 +177,14 @@ def test_mongo_wait_for_calc_timeout_ok():
 
 @cachier(mongetter=_test_mongetter, stale_after=MONGO_DELTA_LONG, next_time=False, wait_for_calc_timeout=2)
 def _wait_for_calc_timeout_mongo_slow(arg_1, arg_2):
+    print("_wait_for_calc_timeout_mongo_slow")
     """Some function."""
     sleep(3)
     return random() + arg_1 + arg_2
 
 
 def _calls_wait_for_calc_timeout_mongo_slow(res_queue):
+    print("_calls_wait_for_calc_timeout_mongo_slow")
     res = _wait_for_calc_timeout_mongo_slow(1, 2)
     res_queue.put(res)
 
@@ -190,6 +192,7 @@ def _calls_wait_for_calc_timeout_mongo_slow(res_queue):
 def test_mongo_wait_for_calc_timeout_slow():
     """Testing for calls timing out to be performed twice when needed."""
     _wait_for_calc_timeout_mongo_slow.clear_cache()
+    print("Cache cleared")
     res_queue = queue.Queue()
     thread1 = threading.Thread(
         target=_calls_wait_for_calc_timeout_mongo_slow, kwargs={'res_queue': res_queue})
@@ -198,7 +201,7 @@ def test_mongo_wait_for_calc_timeout_slow():
 
     thread1.start()
     thread2.start()
-    sleep(3)
+    sleep(4)
     thread1.join()
     thread2.join()    
     assert res_queue.qsize() == 2

--- a/tests/test_mongo_core.py
+++ b/tests/test_mongo_core.py
@@ -177,14 +177,11 @@ def test_mongo_wait_for_calc_timeout_ok():
 
 @cachier(mongetter=_test_mongetter, stale_after=MONGO_DELTA_LONG, next_time=False, wait_for_calc_timeout=2)
 def _wait_for_calc_timeout_mongo_slow(arg_1, arg_2):
-    print("_wait_for_calc_timeout_mongo_slow")
-    """Some slow function."""
     sleep(3)
     return random() + arg_1 + arg_2
 
 
 def _calls_wait_for_calc_timeout_mongo_slow(res_queue):
-    print("_calls_wait_for_calc_timeout_mongo_slow")
     res = _wait_for_calc_timeout_mongo_slow(1, 2)
     res_queue.put(res)
 
@@ -192,7 +189,6 @@ def _calls_wait_for_calc_timeout_mongo_slow(res_queue):
 def test_mongo_wait_for_calc_timeout_slow():
     """Testing for calls timing out to be performed twice when needed."""
     _wait_for_calc_timeout_mongo_slow.clear_cache()
-    print("Cache cleared")
     res_queue = queue.Queue()
     thread1 = threading.Thread(
         target=_calls_wait_for_calc_timeout_mongo_slow, kwargs={'res_queue': res_queue})

--- a/tests/test_mongo_core.py
+++ b/tests/test_mongo_core.py
@@ -178,7 +178,7 @@ def test_mongo_wait_for_calc_timeout_ok():
 @cachier(mongetter=_test_mongetter, stale_after=MONGO_DELTA_LONG, next_time=False, wait_for_calc_timeout=2)
 def _wait_for_calc_timeout_mongo_slow(arg_1, arg_2):
     print("_wait_for_calc_timeout_mongo_slow")
-    """Some function."""
+    """Some slow function."""
     sleep(3)
     return random() + arg_1 + arg_2
 

--- a/tests/test_mongo_core.py
+++ b/tests/test_mongo_core.py
@@ -201,15 +201,17 @@ def test_mongo_wait_for_calc_timeout_slow():
 
     thread1.start()
     thread2.start()
+    sleep(1)
+    res3 = _wait_for_calc_timeout_mongo_slow(1, 2)
     sleep(4)
     thread1.join()
-    thread2.join()    
+    thread2.join()
     assert res_queue.qsize() == 2
     res1 = res_queue.get()
     res2 = res_queue.get()
     assert res1 != res2 # Timeout kicked in.  Two calls were done
-    res3 = _wait_for_calc_timeout_mongo_slow(1, 2)
-    assert res2 == res3 or res1 == res3 # One of the cached values is returned
+    res4 = _wait_for_calc_timeout_mongo_slow(1, 2)
+    assert res1 == res4 or res2 == res4 or res3 == res4 # One of the cached values is returned
 
 
 class _BadMongoCollection:

--- a/tests/test_mongo_core.py
+++ b/tests/test_mongo_core.py
@@ -92,7 +92,7 @@ def test_mongo_core():
 
 
 MONGO_DELTA = timedelta(seconds=3)
-
+MONGO_DELTA_LONG = timedelta(seconds=10)
 
 @cachier(mongetter=_test_mongetter, stale_after=MONGO_DELTA, next_time=False)
 def _stale_after_mongo(arg_1, arg_2):
@@ -156,7 +156,8 @@ def test_mongo_wait_for_calc_timeout_ok():
     assert val1 == val2
 
 
-@cachier(mongetter=_test_mongetter, stale_after=MONGO_DELTA, next_time=False, wait_for_calc_timeout=2)
+
+@cachier(mongetter=_test_mongetter, stale_after=MONGO_DELTA_LONG, next_time=False, wait_for_calc_timeout=2)
 def _wait_for_calc_timeout_mongo_slow(arg_1, arg_2):
     """Some function."""
     sleep(3)
@@ -185,7 +186,9 @@ def test_mongo_wait_for_calc_timeout_slow():
     assert res_queue.qsize() == 2
     res1 = res_queue.get()
     res2 = res_queue.get()
-    assert res1 != res2
+    assert res1 != res2 # Timeout kicked in, hence two calls were done
+    res3 = _wait_for_calc_timeout_mongo_slow(1, 2)
+    assert res2 == res3 # The cached value is returned
 
 
 class _BadMongoCollection:


### PR DESCRIPTION
While using Cachier in Production I noticed there exist chances of ending in deadlocks.

Steps to reproduce:
1. Decorate a function that takes a sensitive amount of time.
2. Stop the process before the result is computed.
3. The DB will end up with a record flagged as `being_calculated = true`
4. Successive calls will end up looping forever in [this line](https://github.com/shaypal5/cachier/blob/master/cachier/mongo_core.py#L135).


Note the solution I'm proposing will double calls.
