### PR TITLE
Make cachier() more abstract for using other cores

### DIFF
--- a/cachier/core.py
+++ b/cachier/core.py
@@ -135,7 +135,12 @@ def cachier(
     # print('stale_after={}'.format(stale_after))
     # print('next_time={}'.format(next_time))
 
-    if backend is None or backend == 'pickle':
+    # The default is calculated dynamically to maintain previous behavior
+    # to default to pickle unless the ``mongetter`` argument is given.
+    if backend is None:
+        backend = 'pickle' if mongetter is None else 'mongo'
+
+    if backend == 'pickle':
         core = _PickleCore(  # pylint: disable=R0204
             stale_after=stale_after,
             next_time=next_time,

--- a/cachier/core.py
+++ b/cachier/core.py
@@ -73,6 +73,10 @@ def _calc_entry(core, key, func, args, kwds):
         core.mark_entry_not_calculated(key)
 
 
+class MissingMongetter(ValueError):
+    """Thrown when the mongetter keyword argument is missing."""
+
+
 def cachier(
     stale_after=None,
     next_time=False,
@@ -150,7 +154,7 @@ def cachier(
         )
     elif backend == 'mongo':
         if mongetter is None:
-            raise ValueError('must specify ``mongetter`` when using the mongo core')
+            raise MissingMongetter('must specify ``mongetter`` when using the mongo core')
         core = _MongoCore(mongetter, stale_after, next_time, wait_for_calc_timeout)
     elif backend == 'memory':
         raise NotImplementedError(

--- a/cachier/core.py
+++ b/cachier/core.py
@@ -112,8 +112,9 @@ def cachier(
         object with writing permissions. If unset a local pickle cache is used
         instead.
     backend : str, optional
-        The name of the backend to use. Defaults to 'pickle' if None. Other
-        valid options include 'pickle' and 'mongo'.
+        The name of the backend to use. If None, defaults to 'mongo' when
+        the ``mongetter`` argument is passed, otherwise defaults to 'pickle'.
+        Valid options currently include 'pickle' and 'mongo'.
     cache_dir : str, optional
         A fully qualified path to a file directory to be used for cache files.
         The running process must have running permissions to this folder. If

--- a/cachier/core.py
+++ b/cachier/core.py
@@ -146,6 +146,16 @@ def cachier(
         if mongetter is None:
             raise ValueError('must specify ``mongetter`` when using the mongo core')
         core = _MongoCore(mongetter, stale_after, next_time, wait_for_calc_timeout)
+    elif backend == 'memory':
+        raise NotImplementedError(
+            'An in-memory backend has not yet been implemented. '
+            'Please see https://github.com/shaypal5/cachier/issues/6'
+        )
+    elif backend == 'redis':
+        raise NotImplementedError(
+            'A Redis backend has not yet been implemented. '
+            'Please see https://github.com/shaypal5/cachier/issues/4'
+        )
     else:
         raise ValueError('specified an invalid core: {}'.format(backend))
 

--- a/tests/test_core_lookup.py
+++ b/tests/test_core_lookup.py
@@ -1,0 +1,29 @@
+"""Testing the MongoDB core of cachier."""
+
+from cachier import cachier
+from cachier.core import MissingMongetter
+
+
+def test_bad_name():
+    """Test that the appropriate exception is thrown when an invalid backend is given."""
+    name = 'nope'
+    try:
+        @cachier(backend=name)
+        def func():
+            pass
+    except ValueError as e:
+        assert name in e.args[0]
+    else:
+        assert False
+
+
+def test_missing_mongetter():
+    """Test that the appropriate exception is thrown when forgetting to specify the mongetter."""
+    try:
+        @cachier(backend='mongo', mongetter=None)
+        def func():
+            pass
+    except MissingMongetter:
+        assert True
+    else:
+        assert False


### PR DESCRIPTION
This PR adds the `backend` argument to the `cachier()` to allow users to explicitly set the core that is used. Right now, it does not include any new cores, but does give an example as to where potential codes supporting #4 and #6 could be added.

Sidebar: it might be the case that later, it needs to be reinvestigated how arguments are passed to the core - if there are many cores, having all of their extra arguments inside the `cachier()` function could get verbose. One way might be to use `**kwargs`, but I think it's worth waiting until other cores are implemented to worry about that abstractions.

If you're happy with this PR, I would also like to take a stab at implementing #6.