### PR TITLE
added sentinel value between args and kwargs when generating entry key

### DIFF
--- a/cachier/base_core.py
+++ b/cachier/base_core.py
@@ -56,3 +56,10 @@ class _BaseCore():
     @abc.abstractmethod
     def clear_being_calculated(self):
         """Marks all entries in this cache as not being calculated."""
+
+class _Sentinel:
+    def __eq__(self, other):
+        return isinstance(other, self.__class__)
+
+    def __hash__(self):
+        return 0

--- a/cachier/mongo_core.py
+++ b/cachier/mongo_core.py
@@ -23,7 +23,7 @@ try:
 except ImportError:  # pragma: no cover
     pass
 
-from .base_core import _BaseCore
+from .base_core import _BaseCore, _Sentinel
 
 
 MONGO_SLEEP_DURATION_IN_SEC = 1
@@ -80,7 +80,7 @@ class _MongoCore(_BaseCore):
         return key, None
 
     def get_entry(self, args, kwds, hash_params):
-        key = pickle.dumps(args + tuple(sorted(kwds.items())) if hash_params is None else hash_params(args, kwds))
+        key = pickle.dumps(args + (_Sentinel(),) + tuple(sorted(kwds.items())) if hash_params is None else hash_params(args, kwds))
         return self.get_entry_by_key(key)
 
     def set_entry(self, key, func_res):

--- a/cachier/pickle_core.py
+++ b/cachier/pickle_core.py
@@ -18,7 +18,7 @@ from watchdog.events import PatternMatchingEventHandler
 
 # Altenative:  https://github.com/WoLpH/portalocker
 
-from .base_core import _BaseCore
+from .base_core import _BaseCore, _Sentinel
 
 
 DEF_CACHIER_DIR = '~/.cachier/'
@@ -147,7 +147,7 @@ class _PickleCore(_BaseCore):
             return key, self._get_cache().get(key, None)
 
     def get_entry(self, args, kwds, hash_params):
-        key = args + tuple(sorted(kwds.items())) if hash_params is None else hash_params(args, kwds)
+        key = args + (_Sentinel(),) + tuple(sorted(kwds.items())) if hash_params is None else hash_params(args, kwds)
         # print('key type={}, key={}'.format(type(key), key))
         return self.get_entry_by_key(key)
 

--- a/tests/test_pickle_core.py
+++ b/tests/test_pickle_core.py
@@ -427,3 +427,15 @@ def test_callable_hash_param():
     value_b = _params_with_dataframe(1, df=df_b)
 
     assert value_a == value_b  # same content --> same key
+
+def test_cache_key():
+    """Test that the calls some_func(1, ("a", 2)) and some_func(1, a=2)
+    are distinguished by the cache."""
+
+    @cachier()
+    def some_func(*args, **kwargs):
+        return len(kwargs) > 0
+
+    some_func(1, ("a", 2))
+
+    assert some_func(1, a=2)


### PR DESCRIPTION
To create the key for a cache entry, the current implementation uses the following expression:

```
key = args + tuple(sorted(kwds.items())) ...
```

For a function with signature `spam(*args, **kwargs)`, this will generate the same key for `spam(1, a=2)` and `spam(1, ("a", 2))`, which may be undesirable.

This is solved by inserting a sentinel value to mark the boundary between `args` and `kwds` when creating the key. From the example above, instead of both calls having the key `(1, ("a", 2))`, they have keys `(1, _Sentinel, ("a", 2))` and `(1, ("a", 2), _Sentinel)` respectively.