### PR TITLE
Allow concurrent cache reads with pickle core

### DIFF
--- a/cachier/pickle_core.py
+++ b/cachier/pickle_core.py
@@ -121,7 +121,7 @@ class _PickleCore(_BaseCore):
         with self.lock:
             fpath = self._cache_fpath()
             try:
-                with portalocker.Lock(fpath, mode='rb') as cache_file:
+                with portalocker.Lock(fpath, mode='rb', flags=portalocker.LOCK_SH) as cache_file:
                     try:
                         self.cache = pickle.load(cache_file)
                     except EOFError:
@@ -142,7 +142,7 @@ class _PickleCore(_BaseCore):
         else:
             fpath += f'_{hash}'
         try:
-            with portalocker.Lock(fpath, mode='rb') as cache_file:
+            with portalocker.Lock(fpath, mode='rb', flags=portalocker.LOCK_SH) as cache_file:
                 try:
                     res = pickle.load(cache_file)
                 except EOFError:
@@ -176,7 +176,7 @@ class _PickleCore(_BaseCore):
                 fpath += f'_{hashlib.sha256(pickle.dumps(key)).hexdigest()}'
             elif hash is not None:
                 fpath += f'_{hash}'
-            with portalocker.Lock(fpath, mode='wb') as cache_file:
+            with portalocker.Lock(fpath, mode='wb', flags=portalocker.LOCK_EX) as cache_file:
                 pickle.dump(cache, cache_file, protocol=4)
             if key is None:
                 self._reload_cache()


### PR DESCRIPTION
I have a use case where my cache is large, rarely written to, but read by many different threads at the same time thus causing timeout errors because only one thread can read the cache at the same time.

This PR allows multiple threads to *read* the cache using a shared lock but still preserve the thread-safety by requesting an exclusive lock on cache *writes*.

Therefore if multiple threads want to read the cache then they can do so simultaneously, but if only a single thread wants to write to it, then it needs to acquire an exclusive lock that prevents all other threads to read or write to the cache.


I tested locally for my use case, but would that potentially cause other issues that I didn't think of?