### PR TITLE
Ignore self automatically

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -83,6 +83,21 @@ You can add a default, pickle-based, persistent cache to your function - meaning
     """Your function now has a persistent cache mapped by argument values!"""
     return {'arg1': arg1, 'arg2': arg2}
 
+Class and object methods can also be cached. Cachier will automatically ignore the `self` parameter when determining the cache key for an object method.
+
+.. code-block:: python
+
+  from cachier import cachier
+
+  class Foo():
+    @staticmethod
+    @cachier()
+    def bar(arg_1, arg_2):
+      return {'arg1': arg1, 'arg2': arg2}
+
+    @cachier()
+    def baz(self, arg_1, arg_2)
+      return {'arg1': arg1, 'arg2': arg2}
 
 
 Resetting a Cache
@@ -381,5 +396,3 @@ Notable bugfixers:
 .. links:
 .. _pymongo: https://api.mongodb.com/python/current/
 .. _watchdog: https://github.com/gorakhargosh/watchdog
-
-

--- a/cachier/base_core.py
+++ b/cachier/base_core.py
@@ -9,6 +9,7 @@
 import abc  # for the _BaseCore abstract base class
 import functools
 import hashlib
+import inspect
 
 
 def _default_hash_params(args, kwds):
@@ -27,8 +28,10 @@ class _BaseCore():
         self.func = None
 
     def set_func(self, func):
-        """Sets the function this core will use. This has to be set before
-        any method is called"""
+        """Sets the function this core will use. This has to be set before any
+        method is called. Also determine if the funtion is an object method."""
+        func_params = list(inspect.signature(func).parameters)
+        self.func_is_method = func_params and func_params[0] == 'self'
         self.func = func
 
     def get_entry(self, args, kwds):

--- a/cachier/core.py
+++ b/cachier/core.py
@@ -194,7 +194,10 @@ def cachier(
                 _print = print
             if ignore_cache:
                 return func(*args, **kwds)
-            key, entry = core.get_entry(args, kwds)
+            if core.func_is_method:
+                key, entry = core.get_entry(args[1:], kwds)
+            else:
+                key, entry = core.get_entry(args, kwds)
             if overwrite_cache:
                 return _calc_entry(core, key, func, args, kwds)
             if entry is not None:  # pylint: disable=R0101


### PR DESCRIPTION
@shaypal5 this change automatically ignores `self` if it's the first argument of a function's definition. This allows object methods to be cached across object instantiations. This has to be used with some care if the function result depends on the internal state of the object, but in my use case the class is an API client, and I want to be able to cache methods to avoid network round trips when the data is fresh.

This branch is on top of `better-tests` so would makes sense to merge that one first: https://github.com/python-cachier/cachier/pull/106.

Fixes #11 
Fixes #28 