### PR TITLE
Ignore self parameter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -83,6 +83,33 @@ You can add a default, pickle-based, persistent cache to your function - meaning
     """Your function now has a persistent cache mapped by argument values!"""
     return {'arg1': arg1, 'arg2': arg2}
 
+Class and object methods can also be cached. Cachier will automatically ignore the `self` parameter when determining the cache key for an object method. **This means that methods will be cached across all instances of an object, which may not be what you want.**
+
+.. code-block:: python
+
+  from cachier import cachier
+
+  class Foo():
+    @staticmethod
+    @cachier()
+    def good_static_usage(arg_1, arg_2):
+      return arg_1 + arg_2
+
+    # Instance method does not depend on object's internal state, so good to cache
+    @cachier()
+    def good_usage_1(self, arg_1, arg_2)
+      return arg_1 + arg_2
+
+    # Instance method is calling external service, probably okay to cache
+    @cachier()
+    def good_usage_2(self, arg_1, arg_2)
+      result = self.call_api(arg_1, arg_2)
+      return result
+
+    # Instance method relies on object attribute, NOT good to cache
+    @cachier()
+    def bad_usage(self, arg_1, arg_2)
+      return arg_1 + arg_2 + self.arg_3
 
 
 Resetting a Cache

--- a/cachier/base_core.py
+++ b/cachier/base_core.py
@@ -9,6 +9,7 @@
 import abc  # for the _BaseCore abstract base class
 import functools
 import hashlib
+import inspect
 
 
 def _default_hash_params(args, kwds):
@@ -27,8 +28,10 @@ class _BaseCore():
         self.func = None
 
     def set_func(self, func):
-        """Sets the function this core will use. This has to be set before
-        any method is called"""
+        """Sets the function this core will use. This has to be set before any
+        method is called. Also determine if the funtion is an object method."""
+        func_params = list(inspect.signature(func).parameters)
+        self.func_is_method = func_params and func_params[0] == 'self'
         self.func = func
 
     def get_entry(self, args, kwds):

--- a/cachier/core.py
+++ b/cachier/core.py
@@ -194,7 +194,10 @@ def cachier(
                 _print = print
             if ignore_cache:
                 return func(*args, **kwds)
-            key, entry = core.get_entry(args, kwds)
+            if core.func_is_method:
+                key, entry = core.get_entry(args[1:], kwds)
+            else:
+                key, entry = core.get_entry(args, kwds)
             if overwrite_cache:
                 return _calc_entry(core, key, func, args, kwds)
             if entry is not None:  # pylint: disable=R0101

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -5,7 +5,7 @@ import os
 import queue
 import threading
 from random import random
-from time import sleep
+from time import sleep, time
 import pytest
 import cachier as cachier_dir
 from cachier import cachier
@@ -169,3 +169,33 @@ def test_precache_value(mongetter, backend):
     assert result == 5
     result = func(2, arg_2=2)
     assert result == 5
+
+
+@pytest.mark.parametrize(
+    'mongetter,backend',
+    [
+        (_test_mongetter, 'mongo'),
+        (None, 'memory'),
+        (None, 'pickle'),
+    ]
+)
+def test_ignore_self_in_methods(mongetter, backend):
+
+    class TestClass():
+        @cachier(backend=backend, mongetter=mongetter)
+        def takes_2_seconds(self, arg_1, arg_2):
+            """Some function."""
+            sleep(2)
+            return arg_1 + arg_2
+
+    test_object_1 = TestClass()
+    test_object_2 = TestClass()
+    test_object_1.takes_2_seconds.clear_cache()
+    test_object_2.takes_2_seconds.clear_cache()
+    result_1 = test_object_1.takes_2_seconds(1, 2)
+    assert result_1 == 3
+    start = time()
+    result_2 = test_object_2.takes_2_seconds(1, 2)
+    end = time()
+    assert result_2 == 3
+    assert end - start < 1


### PR DESCRIPTION
@shaypal5 this change automatically ignores self if it's the first argument of a function's definition. This allows object methods to be cached across object instantiations. This has to be used with some care if the function result depends on the internal state of the object, but in my use case the class is an API client, and I want to be able to cache methods to avoid network round trips when the data is fresh.

Fixes #11 
Fixes #28 