### PR TITLE
Fix inconsistent hashing bug

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -162,11 +162,15 @@ Further function calls made while the calculation is being performed will not tr
 Working with unhashable arguments
 ---------------------------------
 
-As mentioned above, the positional and keyword arguments to the wrapped function must be hashable (i.e. Python's immutable built-in objects, not mutable containers). To get around this limitation the ``hash_params`` parameter of the ``cachier`` decorator can be provided with a callable that gets the args and kwargs from the decorated function and returns a hash key for them.
+As mentioned above, the positional and keyword arguments to the wrapped function must be hashable (i.e. Python's immutable built-in objects, not mutable containers). To get around this limitation the ``hash_func`` parameter of the ``cachier`` decorator can be provided with a callable that gets the args and kwargs from the decorated function and returns a hash key for them.
 
 .. code-block:: python
 
-  @cachier(hash_params=hash_my_custom_class)
+  def calculate_hash(args, kwds):
+    key = ...  # compute a hash key here based on arguments
+    return key
+
+  @cachier(hash_func=calculate_hash)
   def calculate_super_complex_stuff(custom_obj):
     # amazing code goes here
 
@@ -381,7 +385,7 @@ Other major contributors:
 
   * `cthoyt <https://github.com/cthoyt>`_ - Base memory core implementation.
 
-  * `amarczew <https://github.com/amarczew>`_ - The ``hash_params`` kwarg.
+  * `amarczew <https://github.com/amarczew>`_ - The ``hash_func`` kwarg.
 
   * `non-senses <https://github.com/non-senses>`_ - The ``wait_for_calc_timeout`` kwarg.
 

--- a/cachier/base_core.py
+++ b/cachier/base_core.py
@@ -21,9 +21,7 @@ def _default_hash_params(args, kwds):
 class _BaseCore():
     __metaclass__ = abc.ABCMeta
 
-    def __init__(self, stale_after, next_time, hash_params):
-        self.stale_after = stale_after
-        self.next_time = next_time
+    def __init__(self, hash_params):
         self.hash_func = hash_params if hash_params else _default_hash_params
         self.func = None
 

--- a/cachier/base_core.py
+++ b/cachier/base_core.py
@@ -12,7 +12,7 @@ import hashlib
 import inspect
 
 
-def _default_hash_params(args, kwds):
+def _default_hash_func(args, kwds):
     # pylint: disable-next=protected-access
     key = functools._make_key(args, kwds, typed=False)
     return hashlib.sha256(str(hash(key)).encode()).hexdigest()
@@ -21,8 +21,8 @@ def _default_hash_params(args, kwds):
 class _BaseCore():
     __metaclass__ = abc.ABCMeta
 
-    def __init__(self, hash_params):
-        self.hash_func = hash_params if hash_params else _default_hash_params
+    def __init__(self, hash_func):
+        self.hash_func = hash_func if hash_func else _default_hash_func
         self.func = None
 
     def set_func(self, func):

--- a/cachier/base_core.py
+++ b/cachier/base_core.py
@@ -10,12 +10,16 @@ import abc  # for the _BaseCore abstract base class
 import functools
 import hashlib
 import inspect
+import pickle  # nosec: B403
 
 
 def _default_hash_func(args, kwds):
     # pylint: disable-next=protected-access
-    key = functools._make_key(args, kwds, typed=False)
-    return hashlib.sha256(str(hash(key)).encode()).hexdigest()
+    key = functools._make_key(args, kwds, typed=True)
+    hash = hashlib.sha256()
+    for item in key:
+        hash.update(pickle.dumps(item))
+    return hash.hexdigest()
 
 
 class _BaseCore():

--- a/cachier/core.py
+++ b/cachier/core.py
@@ -147,8 +147,6 @@ def cachier(
         backend = 'pickle' if mongetter is None else 'mongo'
     if backend == 'pickle':
         core = _PickleCore(  # pylint: disable=R0204
-            stale_after=stale_after,
-            next_time=next_time,
             hash_params=hash_params,
             reload=pickle_reload,
             cache_dir=cache_dir,
@@ -161,15 +159,11 @@ def cachier(
                 'must specify ``mongetter`` when using the mongo core')
         core = _MongoCore(
             mongetter=mongetter,
-            stale_after=stale_after,
-            next_time=next_time,
             hash_params=hash_params,
             wait_for_calc_timeout=wait_for_calc_timeout,
         )
     elif backend == 'memory':
         core = _MemoryCore(
-            stale_after=stale_after,
-            next_time=next_time,
             hash_params=hash_params,
         )
     elif backend == 'redis':

--- a/cachier/memory_core.py
+++ b/cachier/memory_core.py
@@ -17,8 +17,8 @@ class _MemoryCore(_BaseCore):
         See :class:`_BaseCore` documentation.
     """
 
-    def __init__(self, stale_after, next_time, hash_params):
-        super().__init__(stale_after, next_time, hash_params)
+    def __init__(self, hash_params):
+        super().__init__(hash_params)
         self.cache = {}
         self.lock = threading.RLock()
 

--- a/cachier/memory_core.py
+++ b/cachier/memory_core.py
@@ -17,8 +17,8 @@ class _MemoryCore(_BaseCore):
         See :class:`_BaseCore` documentation.
     """
 
-    def __init__(self, hash_params):
-        super().__init__(hash_params)
+    def __init__(self, hash_func):
+        super().__init__(hash_func)
         self.cache = {}
         self.lock = threading.RLock()
 

--- a/cachier/mongo_core.py
+++ b/cachier/mongo_core.py
@@ -37,12 +37,12 @@ class _MongoCore(_BaseCore):
 
     _INDEX_NAME = 'func_1_key_1'
 
-    def __init__(self, mongetter, hash_params, wait_for_calc_timeout):
+    def __init__(self, mongetter, hash_func, wait_for_calc_timeout):
         if 'pymongo' not in sys.modules:
             warnings.warn((
                 "Cachier warning: pymongo was not found. "
                 "MongoDB cores will not function."))
-        super().__init__(hash_params)
+        super().__init__(hash_func)
         self.mongetter = mongetter
         self.mongo_collection = self.mongetter()
         self.wait_for_calc_timeout = wait_for_calc_timeout

--- a/cachier/mongo_core.py
+++ b/cachier/mongo_core.py
@@ -37,14 +37,12 @@ class _MongoCore(_BaseCore):
 
     _INDEX_NAME = 'func_1_key_1'
 
-    def __init__(
-            self, mongetter, stale_after, next_time,
-            hash_params, wait_for_calc_timeout):
+    def __init__(self, mongetter, hash_params, wait_for_calc_timeout):
         if 'pymongo' not in sys.modules:
             warnings.warn((
                 "Cachier warning: pymongo was not found. "
                 "MongoDB cores will not function."))
-        super().__init__(stale_after, next_time, hash_params)
+        super().__init__(hash_params)
         self.mongetter = mongetter
         self.mongo_collection = self.mongetter()
         self.wait_for_calc_timeout = wait_for_calc_timeout

--- a/cachier/pickle_core.py
+++ b/cachier/pickle_core.py
@@ -80,10 +80,10 @@ class _PickleCore(_BaseCore):
             self._check_calculation()
 
     def __init__(
-            self, hash_params, reload, cache_dir,
+            self, hash_func, reload, cache_dir,
             separate_files, wait_for_calc_timeout,
     ):
-        super().__init__(hash_params)
+        super().__init__(hash_func)
         self.cache = None
         self.reload = reload
         self.cache_dir = DEF_CACHIER_DIR

--- a/cachier/pickle_core.py
+++ b/cachier/pickle_core.py
@@ -29,10 +29,6 @@ class _PickleCore(_BaseCore):
 
     Parameters
     ----------
-    stale_after : datetime.timedelta, optional
-        See _BaseCore documentation.
-    next_time : bool, optional
-        See _BaseCore documentation.
     pickle_reload : bool, optional
         See core.cachier() documentation.
     cache_dir : str, optional.
@@ -84,10 +80,10 @@ class _PickleCore(_BaseCore):
             self._check_calculation()
 
     def __init__(
-            self, stale_after, next_time, hash_params, reload,
-            cache_dir, separate_files, wait_for_calc_timeout,
+            self, hash_params, reload, cache_dir,
+            separate_files, wait_for_calc_timeout,
     ):
-        super().__init__(stale_after, next_time, hash_params)
+        super().__init__(hash_params)
         self.cache = None
         self.reload = reload
         self.cache_dir = DEF_CACHIER_DIR

--- a/tests/standalone_script.py
+++ b/tests/standalone_script.py
@@ -1,0 +1,11 @@
+import cachier
+import time
+
+
+@cachier.cachier()
+def _takes_3_seconds(label, value):
+    time.sleep(3)
+    return f'{label} {value}'
+
+
+print(_takes_3_seconds('two', 2))

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -1,8 +1,10 @@
 """Non-core-specific tests for cachier."""
 
 from __future__ import print_function
+import functools
 import os
 import queue
+import subprocess  # nosec: B404
 import threading
 from random import random
 from time import sleep, time
@@ -207,3 +209,16 @@ def test_hash_params_deprecation():
         def test():
             return 'value'
     assert test() == 'value'
+
+
+def test_separate_processes():
+    test_args = ('python', 'tests/standalone_script.py')
+    run_params = {'args': test_args, 'capture_output': True, 'text': True}
+    run_process = functools.partial(subprocess.run, **run_params)
+    result = run_process()
+    assert result.stdout.strip() == 'two 2'
+    start = time()
+    result = run_process()
+    end = time()
+    assert result.stdout.strip() == 'two 2'
+    assert end - start < 3

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -199,3 +199,11 @@ def test_ignore_self_in_methods(mongetter, backend):
     end = time()
     assert result_2 == 3
     assert end - start < 1
+
+
+def test_hash_params_deprecation():
+    with pytest.deprecated_call(match='hash_params will be removed'):
+        @cachier(hash_params=lambda a, k: 'key')
+        def test():
+            return 'value'
+    assert test() == 'value'

--- a/tests/test_memory_core.py
+++ b/tests/test_memory_core.py
@@ -283,7 +283,7 @@ def test_error_throwing_func():
 
 @pytest.mark.memory
 def test_callable_hash_param():
-    def _hash_params(args, kwargs):
+    def _hash_func(args, kwargs):
         def _hash(obj):
             if isinstance(obj, pd.core.frame.DataFrame):
                 return hashlib.sha256(
@@ -295,7 +295,7 @@ def test_callable_hash_param():
             {k: _hash(v) for k, v in kwargs.items()}.items()))
         return k_args + k_kwargs
 
-    @cachier(backend='memory', hash_params=_hash_params)
+    @cachier(backend='memory', hash_func=_hash_func)
     def _params_with_dataframe(*args, **kwargs):
         """Some function."""
         return random()

--- a/tests/test_mongo_core.py
+++ b/tests/test_mongo_core.py
@@ -209,7 +209,7 @@ def test_stalled_mongo_db_cache():
     @cachier(mongetter=_test_mongetter)
     def _stalled_func():
         return 1
-    core = _MongoCore(_test_mongetter, None, False, None, 0)
+    core = _MongoCore(_test_mongetter, None, 0)
     core.set_func(_stalled_func)
     core.clear_cache()
     with pytest.raises(RecalculationNeeded):

--- a/tests/test_mongo_core.py
+++ b/tests/test_mongo_core.py
@@ -262,7 +262,7 @@ def test_stalled_mong_db_core(monkeypatch):
 @pytest.mark.mongo
 def test_callable_hash_param():
 
-    def _hash_params(args, kwargs):
+    def _hash_func(args, kwargs):
         def _hash(obj):
             if isinstance(obj, pd.core.frame.DataFrame):
                 return hashlib.sha256(
@@ -275,7 +275,7 @@ def test_callable_hash_param():
             k: _hash(v) for k, v in kwargs.items()}.items()))
         return k_args + k_kwargs
 
-    @cachier(mongetter=_test_mongetter, hash_params=_hash_params)
+    @cachier(mongetter=_test_mongetter, hash_func=_hash_func)
     def _params_with_dataframe(*args, **kwargs):
         """Some function."""
         return random()

--- a/tests/test_pickle_core.py
+++ b/tests/test_pickle_core.py
@@ -534,7 +534,7 @@ def test_pickle_core_custom_cache_dir(separate_files):
 
 @pytest.mark.parametrize('separate_files', [True, False])
 def test_callable_hash_param(separate_files):
-    def _hash_params(args, kwargs):
+    def _hash_func(args, kwargs):
         def _hash(obj):
             if isinstance(obj, pd.core.frame.DataFrame):
                 return hashlib.sha256(
@@ -550,7 +550,7 @@ def test_callable_hash_param(separate_files):
         )
         return k_args + k_kwargs
 
-    @cachier(hash_params=_hash_params, separate_files=separate_files)
+    @cachier(hash_func=_hash_func, separate_files=separate_files)
     def _params_with_dataframe(*args, **kwargs):
         """Some function."""
         return random()


### PR DESCRIPTION
I played around with a bunch of different approaches, but the best I could come up with was to use the `_make_key` function to produce a normalized arg list then pickle each item individually and run it through `sha256` to make a final hash. This produces consistent results across executions, at least in the testing I did (including one automated test to make sure this doesn't break in the future).

This PR also includes a few other cleanups that have been recently discussed.

Fixes #95 
Fixes #114 