### PR TITLE
Make all test threads daemons to keep CI/CD from hanging.

### DIFF
--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -86,10 +86,12 @@ def test_wait_for_calc_timeout_ok(mongetter, stale_after, separate_files):
     res_queue = queue.Queue()
     thread1 = threading.Thread(
         target=_calls_wait_for_calc_timeout_fast,
-        kwargs={'res_queue': res_queue})
+        kwargs={'res_queue': res_queue},
+        daemon=True)
     thread2 = threading.Thread(
         target=_calls_wait_for_calc_timeout_fast,
-        kwargs={'res_queue': res_queue})
+        kwargs={'res_queue': res_queue},
+        daemon=True)
 
     thread1.start()
     thread2.start()
@@ -124,10 +126,12 @@ def test_wait_for_calc_timeout_slow(mongetter, stale_after, separate_files):
     res_queue = queue.Queue()
     thread1 = threading.Thread(
         target=_calls_wait_for_calc_timeout_slow,
-        kwargs={'res_queue': res_queue})
+        kwargs={'res_queue': res_queue},
+        daemon=True)
     thread2 = threading.Thread(
         target=_calls_wait_for_calc_timeout_slow,
-        kwargs={'res_queue': res_queue})
+        kwargs={'res_queue': res_queue},
+        daemon=True)
 
     thread1.start()
     thread2.start()

--- a/tests/test_memory_core.py
+++ b/tests/test_memory_core.py
@@ -172,9 +172,13 @@ def test_memory_being_calculated():
     _takes_time.clear_cache()
     res_queue = queue.Queue()
     thread1 = threading.Thread(
-            target=_calls_takes_time, kwargs={'res_queue': res_queue})
+        target=_calls_takes_time,
+        kwargs={'res_queue': res_queue},
+        daemon=True)
     thread2 = threading.Thread(
-            target=_calls_takes_time, kwargs={'res_queue': res_queue})
+        target=_calls_takes_time,
+        kwargs={'res_queue': res_queue},
+        daemon=True)
     thread1.start()
     sleep(0.5)
     thread2.start()
@@ -206,9 +210,13 @@ def test_being_calc_next_time():
     sleep(1.1)
     res_queue = queue.Queue()
     thread1 = threading.Thread(
-        target=_calls_being_calc_next_time, kwargs={'res_queue': res_queue})
+        target=_calls_being_calc_next_time,
+        kwargs={'res_queue': res_queue},
+        daemon=True)
     thread2 = threading.Thread(
-        target=_calls_being_calc_next_time, kwargs={'res_queue': res_queue})
+        target=_calls_being_calc_next_time,
+        kwargs={'res_queue': res_queue},
+        daemon=True)
     thread1.start()
     sleep(0.5)
     thread2.start()
@@ -240,9 +248,13 @@ def test_clear_being_calculated():
     _takes_time.clear_cache()
     res_queue = queue.Queue()
     thread1 = threading.Thread(
-            target=_calls_takes_time, kwargs={'res_queue': res_queue})
+        target=_calls_takes_time,
+        kwargs={'res_queue': res_queue},
+        daemon=True)
     thread2 = threading.Thread(
-            target=_calls_takes_time, kwargs={'res_queue': res_queue})
+        target=_calls_takes_time,
+        kwargs={'res_queue': res_queue},
+        daemon=True)
     thread1.start()
     _takes_time.clear_being_calculated()
     sleep(0.5)

--- a/tests/test_mongo_core.py
+++ b/tests/test_mongo_core.py
@@ -144,9 +144,13 @@ def test_mongo_being_calculated():
     _takes_time.clear_cache()
     res_queue = queue.Queue()
     thread1 = threading.Thread(
-        target=_calls_takes_time, kwargs={'res_queue': res_queue})
+        target=_calls_takes_time,
+        kwargs={'res_queue': res_queue},
+        daemon=True)
     thread2 = threading.Thread(
-        target=_calls_takes_time, kwargs={'res_queue': res_queue})
+        target=_calls_takes_time,
+        kwargs={'res_queue': res_queue},
+        daemon=True)
     thread1.start()
     sleep(1)
     thread2.start()

--- a/tests/test_pickle_core.py
+++ b/tests/test_pickle_core.py
@@ -222,14 +222,16 @@ def test_pickle_being_calculated(separate_files):
         kwargs={
             'takes_time_func': _takes_time_decorated,
             'res_queue': res_queue,
-        }
+        },
+        daemon=True,
     )
     thread2 = threading.Thread(
         target=_calls_takes_time,
         kwargs={
             'takes_time_func': _takes_time_decorated,
             'res_queue': res_queue,
-        }
+        },
+        daemon=True,
     )
     thread1.start()
     sleep(0.5)
@@ -271,14 +273,16 @@ def test_being_calc_next_time(separate_files):
         kwargs={
             'being_calc_func': _being_calc_next_time_decorated,
             'res_queue': res_queue,
-        }
+        },
+        daemon=True,
     )
     thread2 = threading.Thread(
         target=_calls_being_calc_next_time,
         kwargs={
             'being_calc_func': _being_calc_next_time_decorated,
             'res_queue': res_queue,
-        }
+        },
+        daemon=True,
     )
     thread1.start()
     sleep(0.5)
@@ -339,6 +343,7 @@ def _helper_bad_cache_file(sleeptime, separate_files):
             'trash_cache': True,
             'separate_files': separate_files,
         },
+        daemon=True,
     )
     thread2 = threading.Thread(
         target=_calls_bad_cache,
@@ -348,6 +353,7 @@ def _helper_bad_cache_file(sleeptime, separate_files):
             'trash_cache': False,
             'separate_files': separate_files,
         },
+        daemon=True,
     )
     thread1.start()
     sleep(sleeptime)
@@ -427,6 +433,7 @@ def _helper_delete_cache_file(sleeptime, separate_files):
             'del_cache': True,
             'separate_files': separate_files,
         },
+        daemon=True,
     )
     thread2 = threading.Thread(
         target=_calls_delete_cache,
@@ -436,6 +443,7 @@ def _helper_delete_cache_file(sleeptime, separate_files):
             'del_cache': False,
             'separate_files': separate_files,
         },
+        daemon=True,
     )
     thread1.start()
     sleep(sleeptime)


### PR DESCRIPTION
Hanging threads is my suspicion as to what's causes tests to get stuck sometimes. Making all test threads daemons means they'll be terminated when the tests end.

I'm not entirely sure this will correct #118 , but it shouldn't hurt. I'll give it a few days of successful CI/CD runs before closing the issue.