### PR TITLE
Add global defaults including enable/disable

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,6 @@
 [run]
 branch = True
+dynamic_context = test_function
 omit =
     tests/*
     cachier/_version.py

--- a/README.rst
+++ b/README.rst
@@ -139,6 +139,7 @@ The following parameters will only be applied to decorators defined after `set_d
 
 These parameters can be changed at any time and they will apply to all decorators:
 
+*  `caching_enabled`
 *  `stale_after`
 *  `next_time`
 *  `wait_for_calc_timeout`
@@ -149,6 +150,14 @@ Threads Limit
 ~~~~~~~~~~~~~
 
 To limit the number of threads Cachier is allowed to spawn, set the ``CACHIER_MAX_WORKERS`` with the desired number. The defeault is 8, so to enable Cachier to spawn even more threads, you'll have to set a higher limit explicitly.
+
+
+Global Enable/Disable
+---------------------
+
+Caching can be turned off across all decorators by calling `disable_caching`, and then re-activated by calling `enable_caching`.
+
+These functions are convenience wrappers around the `caching_enabled` default setting.
 
 
 Cache Shelf Life

--- a/README.rst
+++ b/README.rst
@@ -123,6 +123,28 @@ The Cachier wrapper adds a ``clear_cache()`` function to each wrapped function. 
 General Configuration
 ----------------------
 
+Global Defaults
+~~~~~~~~~~~~~~~
+
+Settings can be globally configured across all Cachier wrappers through the use of the `set_default_params` function. This function takes the same keyword parameters as the ones defined in the decorator, which can be passed all at once or with multiple calls. Parameters given directly to a decorator take precedence over any values set by this function.
+
+The following parameters will only be applied to decorators defined after `set_default_params` is called:
+
+*  `hash_func`
+*  `backend`
+*  `mongetter`
+*  `cache_dir`
+*  `pickle_reload`
+*  `separate_files`
+
+These parameters can be changed at any time and they will apply to all decorators:
+
+*  `stale_after`
+*  `next_time`
+*  `wait_for_calc_timeout`
+
+The current defaults can be fetched by calling `get_default_params`.
+
 Threads Limit
 ~~~~~~~~~~~~~
 

--- a/cachier/__init__.py
+++ b/cachier/__init__.py
@@ -1,4 +1,11 @@
-from .core import cachier, set_default_params, get_default_params
+from .core import (
+    cachier,
+    set_default_params,
+    get_default_params,
+    enable_caching,
+    disable_caching,
+)
+
 from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions

--- a/cachier/__init__.py
+++ b/cachier/__init__.py
@@ -1,4 +1,4 @@
-from .core import cachier
+from .core import cachier, set_default_params, get_default_params
 from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions

--- a/cachier/memory_core.py
+++ b/cachier/memory_core.py
@@ -7,18 +7,10 @@ from .base_core import _BaseCore
 
 
 class _MemoryCore(_BaseCore):
-    """The pickle core class for cachier.
+    """The memory core class for cachier."""
 
-    Parameters
-    ----------
-    stale_after : datetime.timedelta, optional
-        See :class:`_BaseCore` documentation.
-    next_time : bool, optional
-        See :class:`_BaseCore` documentation.
-    """
-
-    def __init__(self, hash_func):
-        super().__init__(hash_func)
+    def __init__(self, hash_func, default_params):
+        super().__init__(hash_func, default_params)
         self.cache = {}
         self.lock = threading.RLock()
 

--- a/cachier/memory_core.py
+++ b/cachier/memory_core.py
@@ -66,10 +66,10 @@ class _MemoryCore(_BaseCore):
                 entry['condition'] = None
 
     def wait_on_entry_calc(self, key):
-        with self.lock:
+        with self.lock:  # pragma: no cover
             entry = self.cache[key]
             if not entry['being_calculated']:
-                return entry['value']  # pragma: no cover
+                return entry['value']
         entry['condition'].acquire()
         entry['condition'].wait()
         entry['condition'].release()

--- a/cachier/mongo_core.py
+++ b/cachier/mongo_core.py
@@ -35,7 +35,7 @@ class _MongoCore(_BaseCore):
         if 'pymongo' not in sys.modules:
             warnings.warn((
                 "Cachier warning: pymongo was not found. "
-                "MongoDB cores will not function."))
+                "MongoDB cores will not function."))  # pragma: no cover
         super().__init__(hash_func, default_params)
         self.mongetter = mongetter
         self.mongo_collection = self.mongetter()

--- a/cachier/pickle_core.py
+++ b/cachier/pickle_core.py
@@ -146,7 +146,7 @@ class _PickleCore(_BaseCore):
             with portalocker.Lock(fpath, mode='rb') as cache_file:
                 try:
                     res = pickle.load(cache_file)
-                except EOFError:
+                except EOFError:  # pragma: no cover
                     res = None
         except FileNotFoundError:
             res = None

--- a/cachier/pickle_core.py
+++ b/cachier/pickle_core.py
@@ -6,7 +6,6 @@
 # Licensed under the MIT license:
 # http://www.opensource.org/licenses/MIT-license
 # Copyright (c) 2016, Shay Palachy <shaypal5@gmail.com>
-import hashlib
 import os
 import pickle  # for local caching
 from datetime import datetime
@@ -139,7 +138,7 @@ class _PickleCore(_BaseCore):
     def _get_cache_by_key(self, key=None, hash=None):
         fpath = self._cache_fpath()
         if hash is None:
-            fpath += f'_{hashlib.sha256(pickle.dumps(key)).hexdigest()}'
+            fpath += f'_{key}'
         else:
             fpath += f'_{hash}'
         try:
@@ -174,7 +173,7 @@ class _PickleCore(_BaseCore):
             self.cache = cache
             fpath = self._cache_fpath()
             if key is not None:
-                fpath += f'_{hashlib.sha256(pickle.dumps(key)).hexdigest()}'
+                fpath += f'_{key}'
             elif hash is not None:
                 fpath += f'_{hash}'
             with portalocker.Lock(fpath, mode='wb') as cache_file:
@@ -249,8 +248,7 @@ class _PickleCore(_BaseCore):
     def wait_on_entry_calc(self, key):
         if self.separate_files:
             entry = self._get_cache_by_key(key)
-            hexdg = hashlib.sha256(pickle.dumps(key)).hexdigest()
-            filename = f'{self._cache_fname()}_{hexdg}'
+            filename = f'{self._cache_fname()}_{key}'
         else:
             with self.lock:
                 self._reload_cache()

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,8 +4,9 @@ testpaths =
     cachier
 norecursedirs=dist build .tox
 markers =
-    mongo: Test the MondoDb core.
-    memory: test memory core functionalities.
+    mongo: test the MongoDB core
+    memory: test the memory core
+    pickle: test the pickle core
 addopts =
     # --doctest-modules
     --cov=cachier

--- a/tests/test_core_lookup.py
+++ b/tests/test_core_lookup.py
@@ -1,7 +1,23 @@
 """Testing the MongoDB core of cachier."""
 
-from cachier import cachier
+from cachier import cachier, get_default_params
 from cachier.core import MissingMongetter
+
+
+def test_get_default_params():
+    params = get_default_params()
+    assert tuple(sorted(params)) == (
+        'backend',
+        'cache_dir',
+        'caching_enabled',
+        'hash_func',
+        'mongetter',
+        'next_time',
+        'pickle_reload',
+        'separate_files',
+        'stale_after',
+        'wait_for_calc_timeout',
+    )
 
 
 def test_bad_name():

--- a/tests/test_core_lookup.py
+++ b/tests/test_core_lookup.py
@@ -1,4 +1,4 @@
-"""Testing the MongoDB core of cachier."""
+"""Testing a few basic cachier interfaces."""
 
 from cachier import cachier, get_default_params
 from cachier.core import MissingMongetter

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -1,0 +1,220 @@
+import datetime
+import os
+import pytest
+import queue
+import random
+import tempfile
+import threading
+import time
+
+import cachier
+
+from tests.test_mongo_core import _test_mongetter, MONGO_DELTA
+
+
+_default_params = cachier.get_default_params().copy()
+
+
+def setup_function():
+    cachier.set_default_params(**_default_params)
+
+
+def teardown_function():
+    cachier.set_default_params(**_default_params)
+
+
+def test_hash_func_default_param():
+
+    def slow_hash_func(args, kwds):
+        time.sleep(2)
+        return 'hash'
+
+    def fast_hash_func(args, kwds):
+        return 'hash'
+
+    cachier.set_default_params(hash_func=slow_hash_func)
+
+    @cachier.cachier()
+    def global_test_1():
+        return None
+
+    @cachier.cachier(hash_func=fast_hash_func)
+    def global_test_2():
+        return None
+
+    start = time.time()
+    global_test_1()
+    end = time.time()
+    assert end - start > 1
+    start = time.time()
+    global_test_2()
+    end = time.time()
+    assert end - start < 1
+
+
+def test_backend_default_param():
+
+    cachier.set_default_params(backend='memory')
+
+    @cachier.cachier()
+    def global_test_1():
+        return None
+
+    @cachier.cachier(backend='pickle')
+    def global_test_2():
+        return None
+
+    assert global_test_1.cache_dpath() is None
+    assert global_test_2.cache_dpath() is not None
+
+
+def test_mongetter_default_param():
+
+    cachier.set_default_params(mongetter=_test_mongetter)
+
+    @cachier.cachier()
+    def global_test_1():
+        return None
+
+    @cachier.cachier(mongetter=False)
+    def global_test_2():
+        return None
+
+    assert global_test_1.cache_dpath() is None
+    assert global_test_2.cache_dpath() is not None
+
+
+def test_cache_dir_default_param():
+
+    cachier.set_default_params(cache_dir='/path_1')
+
+    @cachier.cachier()
+    def global_test_1():
+        return None
+
+    @cachier.cachier(cache_dir='/path_2')
+    def global_test_2():
+        return None
+
+    assert global_test_1.cache_dpath() == '/path_1'
+    assert global_test_2.cache_dpath() == '/path_2'
+
+
+def test_separate_files_default_param():
+
+    cachier.set_default_params(separate_files=True)
+
+    @cachier.cachier(cache_dir=tempfile.mkdtemp())
+    def global_test_1(arg_1, arg_2):
+        return arg_1 + arg_2
+
+    @cachier.cachier(cache_dir=tempfile.mkdtemp(), separate_files=False)
+    def global_test_2(arg_1, arg_2):
+        return arg_1 + arg_2
+
+    global_test_1.clear_cache()
+    global_test_1(1, 2)
+    global_test_1(3, 4)
+    global_test_2.clear_cache()
+    global_test_2(1, 2)
+    global_test_2(3, 4)
+
+    cache_dir_1 = global_test_1.cache_dpath()
+    cache_dir_2 = global_test_2.cache_dpath()
+    assert len(os.listdir(cache_dir_1)) == 2
+    assert len(os.listdir(cache_dir_2)) == 1
+
+
+parametrize_keys = 'backend,mongetter'
+parametrize_values = [
+    pytest.param('pickle', None, marks=pytest.mark.pickle),
+    pytest.param('mongo', _test_mongetter, marks=pytest.mark.mongo),
+]
+
+
+@pytest.mark.parametrize(parametrize_keys, parametrize_values)
+def test_stale_after_applies_dynamically(backend, mongetter):
+
+    @cachier.cachier(backend=backend, mongetter=mongetter)
+    def _stale_after_test(arg_1, arg_2):
+        """Some function."""
+        return random.random() + arg_1 + arg_2
+
+    cachier.set_default_params(stale_after=MONGO_DELTA)
+
+    _stale_after_test.clear_cache()
+    val1 = _stale_after_test(1, 2)
+    val2 = _stale_after_test(1, 2)
+    assert val1 == val2
+    time.sleep(3)
+    val3 = _stale_after_test(1, 2)
+    assert val3 != val1
+
+
+@pytest.mark.parametrize(parametrize_keys, parametrize_values)
+def test_next_time_applies_dynamically(backend, mongetter):
+
+    NEXT_AFTER_DELTA = datetime.timedelta(seconds=3)
+
+    @cachier.cachier(backend=backend, mongetter=mongetter)
+    def _stale_after_next_time(arg_1, arg_2):
+        """Some function."""
+        return random.random()
+
+    cachier.set_default_params(stale_after=NEXT_AFTER_DELTA, next_time=True)
+
+    _stale_after_next_time.clear_cache()
+    val1 = _stale_after_next_time(1, 2)
+    val2 = _stale_after_next_time(1, 2)
+    val3 = _stale_after_next_time(1, 3)
+    assert val1 == val2
+    assert val1 != val3
+    time.sleep(NEXT_AFTER_DELTA.seconds + 1)
+    val4 = _stale_after_next_time(1, 2)
+    assert val4 == val1
+    time.sleep(0.5)
+    val5 = _stale_after_next_time(1, 2)
+    assert val5 != val1
+    _stale_after_next_time.clear_cache()
+
+
+@pytest.mark.parametrize(parametrize_keys, parametrize_values)
+def test_wait_for_calc_applies_dynamically(backend, mongetter):
+
+    @cachier.cachier(backend=backend, mongetter=mongetter)
+    def _wait_for_calc_timeout_slow(arg_1, arg_2):
+        time.sleep(3)
+        return random.random() + arg_1 + arg_2
+
+    def _calls_wait_for_calc_timeout_slow(res_queue):
+        res = _wait_for_calc_timeout_slow(1, 2)
+        res_queue.put(res)
+
+    cachier.set_default_params(wait_for_calc_timeout=2)
+
+    """Testing for calls timing out to be performed twice when needed."""
+    _wait_for_calc_timeout_slow.clear_cache()
+    res_queue = queue.Queue()
+    thread1 = threading.Thread(
+        target=_calls_wait_for_calc_timeout_slow,
+        kwargs={'res_queue': res_queue},
+        daemon=True)
+    thread2 = threading.Thread(
+        target=_calls_wait_for_calc_timeout_slow,
+        kwargs={'res_queue': res_queue},
+        daemon=True)
+
+    thread1.start()
+    thread2.start()
+    time.sleep(1)
+    res3 = _wait_for_calc_timeout_slow(1, 2)
+    time.sleep(5)
+    thread1.join(timeout=5)
+    thread2.join(timeout=5)
+    assert res_queue.qsize() == 2
+    res1 = res_queue.get()
+    res2 = res_queue.get()
+    assert res1 != res2  # Timeout kicked in.  Two calls were done
+    res4 = _wait_for_calc_timeout_slow(1, 2)
+    # One of the cached values is returned
+    assert res1 == res4 or res2 == res4 or res3 == res4

--- a/tests/test_mongo_core.py
+++ b/tests/test_mongo_core.py
@@ -16,7 +16,8 @@ import pandas as pd
 from pymongo.errors import OperationFailure
 
 from cachier import cachier
-from cachier.mongo_core import _MongoCore, RecalculationNeeded
+from cachier.base_core import RecalculationNeeded
+from cachier.mongo_core import _MongoCore
 
 from pymongo_inmemory import MongoClient
 
@@ -213,7 +214,7 @@ def test_stalled_mongo_db_cache():
     @cachier(mongetter=_test_mongetter)
     def _stalled_func():
         return 1
-    core = _MongoCore(_test_mongetter, None, 0)
+    core = _MongoCore(_test_mongetter, None, 0, {})
     core.set_func(_stalled_func)
     core.clear_cache()
     with pytest.raises(RecalculationNeeded):

--- a/tests/test_mongo_core.py
+++ b/tests/test_mongo_core.py
@@ -263,6 +263,15 @@ def test_stalled_mong_db_core(monkeypatch):
     res = _stalled_func_2()
     assert res == 2
 
+    @cachier(mongetter=_test_mongetter,
+             stale_after=stale_after, next_time=True)
+    def _stalled_func_3():
+        """Testing stalled function"""
+        return 3
+
+    res = _stalled_func_3()
+    assert res == 1
+
 
 @pytest.mark.mongo
 def test_callable_hash_param():

--- a/tests/test_pickle_core.py
+++ b/tests/test_pickle_core.py
@@ -49,6 +49,7 @@ def _takes_2_seconds(arg_1, arg_2):
     return 'arg_1:{}, arg_2:{}'.format(arg_1, arg_2)
 
 
+@pytest.mark.pickle
 @pytest.mark.parametrize('separate_files', [True, False])
 def test_pickle_core(separate_files):
     """Basic Pickle core functionality."""
@@ -63,6 +64,7 @@ def test_pickle_core(separate_files):
     _takes_2_seconds_decorated.clear_cache()
 
 
+@pytest.mark.pickle
 @pytest.mark.parametrize('separate_files', [True, False])
 def test_pickle_core_keywords(separate_files):
     """Basic Pickle core functionality with keyword arguments."""
@@ -86,6 +88,7 @@ def _stale_after_seconds(arg_1, arg_2):
     return random()
 
 
+@pytest.mark.pickle
 @pytest.mark.parametrize('separate_files', [True, False])
 def test_stale_after(separate_files):
     """Testing the stale_after functionality."""
@@ -110,6 +113,7 @@ def _stale_after_next_time(arg_1, arg_2):
     return random()
 
 
+@pytest.mark.pickle
 @pytest.mark.parametrize('separate_files', [True, False])
 def test_stale_after_next_time(separate_files):
     """Testing the stale_after with next_time functionality."""
@@ -141,6 +145,7 @@ def _random_num_with_arg(a):
     return random()
 
 
+@pytest.mark.pickle
 @pytest.mark.parametrize('separate_files', [True, False])
 def test_overwrite_cache(separate_files):
     """Tests that the overwrite feature works correctly."""
@@ -169,6 +174,7 @@ def test_overwrite_cache(separate_files):
     _random_num_with_arg_decorated.clear_cache()
 
 
+@pytest.mark.pickle
 @pytest.mark.parametrize('separate_files', [True, False])
 def test_ignore_cache(separate_files):
     """Tests that the ignore_cache feature works correctly."""
@@ -210,6 +216,7 @@ def _calls_takes_time(takes_time_func, res_queue):
     res_queue.put(res)
 
 
+@pytest.mark.pickle
 @pytest.mark.parametrize('separate_files', [True, False])
 def test_pickle_being_calculated(separate_files):
     """Testing pickle core handling of being calculated scenarios."""
@@ -236,8 +243,8 @@ def test_pickle_being_calculated(separate_files):
     thread1.start()
     sleep(0.5)
     thread2.start()
-    thread1.join(timeout=3)
-    thread2.join(timeout=3)
+    thread1.join(timeout=4)
+    thread2.join(timeout=4)
     assert res_queue.qsize() == 2
     res1 = res_queue.get()
     res2 = res_queue.get()
@@ -255,6 +262,7 @@ def _calls_being_calc_next_time(being_calc_func, res_queue):
     res_queue.put(res)
 
 
+@pytest.mark.pickle
 @pytest.mark.parametrize('separate_files', [True, False])
 def test_being_calc_next_time(separate_files):
     """Testing pickle core handling of being calculated scenarios."""
@@ -372,6 +380,7 @@ def _helper_bad_cache_file(sleeptime, separate_files):
 
 
 # we want this to succeed at leat once
+@pytest.mark.pickle
 @pytest.mark.xfail
 @pytest.mark.parametrize('separate_files', [True, False])
 def test_bad_cache_file(separate_files):
@@ -464,6 +473,7 @@ def _helper_delete_cache_file(sleeptime, separate_files):
     # print(type(res2))
 
 
+@pytest.mark.pickle
 @pytest.mark.xfail
 @pytest.mark.parametrize('separate_files', [False, True])
 def test_delete_cache_file(separate_files):
@@ -476,6 +486,7 @@ def test_delete_cache_file(separate_files):
     assert False
 
 
+@pytest.mark.pickle
 @pytest.mark.parametrize('separate_files', [False, True])
 def test_clear_being_calculated(separate_files):
     """Test pickle core clear `being calculated` functionality."""
@@ -493,6 +504,7 @@ def _error_throwing_func(arg1):
     return 7
 
 
+@pytest.mark.pickle
 @pytest.mark.parametrize('separate_files', [True, False])
 def test_error_throwing_func(separate_files):
     # with
@@ -522,6 +534,7 @@ def _takes_2_seconds_custom_dir(arg_1, arg_2):
     return 'arg_1:{}, arg_2:{}'.format(arg_1, arg_2)
 
 
+@pytest.mark.pickle
 @pytest.mark.parametrize('separate_files', [True, False])
 def test_pickle_core_custom_cache_dir(separate_files):
     """Basic Pickle core functionality."""
@@ -540,6 +553,7 @@ def test_pickle_core_custom_cache_dir(separate_files):
     assert path2test == EXPANDED_CUSTOM_DIR
 
 
+@pytest.mark.pickle
 @pytest.mark.parametrize('separate_files', [True, False])
 def test_callable_hash_param(separate_files):
     def _hash_func(args, kwargs):

--- a/tests/test_pickle_core.py
+++ b/tests/test_pickle_core.py
@@ -32,7 +32,7 @@ import hashlib
 import pandas as pd
 
 from cachier import cachier
-from cachier.pickle_core import DEF_CACHIER_DIR
+from cachier.core import _default_params
 
 
 def _get_decorated_func(func, **kwargs):
@@ -315,7 +315,7 @@ _BAD_CACHE_FNAME_SEPARATE_FILES = (
     '.tests.test_pickle_core._bad_cache_'
     f'{hashlib.sha256(pickle.dumps((0.13, 0.02))).hexdigest()}'
 )
-EXPANDED_CACHIER_DIR = os.path.expanduser(DEF_CACHIER_DIR)
+EXPANDED_CACHIER_DIR = os.path.expanduser(_default_params['cache_dir'])
 _BAD_CACHE_FPATH = os.path.join(EXPANDED_CACHIER_DIR, _BAD_CACHE_FNAME)
 _BAD_CACHE_FPATH_SEPARATE_FILES = os.path.join(
     EXPANDED_CACHIER_DIR, _BAD_CACHE_FNAME_SEPARATE_FILES)

--- a/tests/test_pickle_core.py
+++ b/tests/test_pickle_core.py
@@ -50,11 +50,13 @@ def _takes_2_seconds(arg_1, arg_2):
 
 
 @pytest.mark.pickle
+@pytest.mark.parametrize('reload', [True, False])
 @pytest.mark.parametrize('separate_files', [True, False])
-def test_pickle_core(separate_files):
+def test_pickle_core(reload, separate_files):
     """Basic Pickle core functionality."""
     _takes_2_seconds_decorated = _get_decorated_func(
-        _takes_2_seconds, next_time=False, separate_files=separate_files)
+        _takes_2_seconds, next_time=False,
+        pickle_reload=reload, separate_files=separate_files)
     _takes_2_seconds_decorated.clear_cache()
     _takes_2_seconds_decorated('a', 'b')
     start = time()


### PR DESCRIPTION
Adds new `set_default_params` function to allow setting of global defaults. See description in README and function header for details.

Also adds `enable_caching` and `disable_caching` functions so caching can be turned on or off across all decorators at any time.

Fixes #56 
Fixes #100 
Fixes #117 
