### PR TITLE
Add basic type hints

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10']
+        python-version: ["3.10"]
         os: [ubuntu-latest]
 
     steps:
@@ -22,15 +22,17 @@ jobs:
       - name: set up python '3.10'
         uses: actions/setup-python@v4.5.0
         with:
-          python-version: '3.10'
+          python-version: "3.10"
 
       # Install your linters here
-      - name: Install flake8
+      - name: Install linters
         run: |
-          python -m pip install flake8
+          python -m pip install flake8 mypy
+
       - name: Run linters
         uses: wearerequired/lint-action@v2.3.0
         with:
           flake8: true
+          mypy: true
           continue_on_error: false
           # Enable your linters here

--- a/cachier/_version.py
+++ b/cachier/_version.py
@@ -15,6 +15,7 @@ import os
 import re
 import subprocess
 import sys
+from typing import Callable, Dict
 
 
 def get_keywords():
@@ -51,8 +52,8 @@ class NotThisMethod(Exception):
     """Exception raised if a method is not valid for the current scenario."""
 
 
-LONG_VERSION_PY = {}
-HANDLERS = {}
+LONG_VERSION_PY: Dict[str, str] = {}
+HANDLERS: Dict[str, Dict[str, Callable]] = {}
 
 
 def register_vcs_handler(vcs, method):  # decorator

--- a/cachier/core.py
+++ b/cachier/core.py
@@ -90,21 +90,24 @@ def _default_hash_func(args, kwds):
 class MissingMongetter(ValueError):
     """Thrown when the mongetter keyword argument is missing."""
 
+
 HashFunc = Callable[..., str]
 Mongetter = Callable[[], Collection]
 Backend = Literal["pickle", "mongo", "memory"]
+
 
 class Params(TypedDict):
     caching_enabled: bool
     hash_func: HashFunc
     backend: Backend
     mongetter: Optional[Mongetter]
-    stale_after:  datetime.timedelta
+    stale_after: datetime.timedelta
     next_time: bool
     cache_dir: Union[str, os.PathLike]
-    pickle_reload:  bool
+    pickle_reload: bool
     separate_files: bool
     wait_for_calc_timeout: int
+
 
 _default_params: Params = {
     'caching_enabled': True,
@@ -119,6 +122,7 @@ _default_params: Params = {
     'wait_for_calc_timeout': 0,
 }
 
+
 def cachier(
     hash_func: Optional[HashFunc] = None,
     hash_params: Optional[HashFunc] = None,
@@ -126,7 +130,7 @@ def cachier(
     mongetter: Optional[Mongetter] = None,
     stale_after: Optional[datetime.timedelta] = None,
     next_time: Optional[bool] = None,
-    cache_dir:Optional[Union[str, os.PathLike]] = None,
+    cache_dir: Optional[Union[str, os.PathLike]] = None,
     pickle_reload: Optional[bool] = None,
     separate_files: Optional[bool] = None,
     wait_for_calc_timeout: Optional[int] = None,

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,11 @@
+[mypy]
+show_column_numbers=true
+show_error_codes=true
+strict_equality=true
+warn_unused_ignores=true
+warn_redundant_casts=true
+warn_unreachable=true
+warn_return_any=false
+
+[mypy-pymongo_inmemory.*]
+ignore_missing_imports = True

--- a/setup.py
+++ b/setup.py
@@ -10,16 +10,17 @@
 try:
     from setuptools import setup
 except ImportError:
-    from distutils.core import setup
+    from distutils.core import setup  # type: ignore
 
 import versioneer
-
 
 TEST_REQUIRES = [
     # tests and coverages
     'pytest', 'coverage', 'pytest-cov',
     # linting and code quality
     'bandit', 'flake8', 'pylint', 'safety',
+    # type checking
+    'mypy', 'types-setuptools', 'pandas-stubs',
     # to connect to the test mongodb server
     'pymongo', 'dnspython', 'pymongo-inmemory',
     # to test pandas dataframe as-param hashing with mongodb core

--- a/tests/test_mongo_core.py
+++ b/tests/test_mongo_core.py
@@ -1,26 +1,24 @@
 """Testing the MongoDB core of cachier."""
 
-import sys
-import platform
 import datetime
+import hashlib
+import platform
+import queue
+import sys
+import threading
 from datetime import timedelta
 from random import random
 from time import sleep
-import threading
-import queue
 
-import pytest
-import pymongo
-import hashlib
 import pandas as pd
+import pymongo
+import pytest
 from pymongo.errors import OperationFailure
+from pymongo_inmemory import MongoClient
 
 from cachier import cachier
 from cachier.base_core import RecalculationNeeded
 from cachier.mongo_core import _MongoCore
-
-from pymongo_inmemory import MongoClient
-
 
 _COLLECTION_NAME = 'cachier_test_{}_{}.{}.{}'.format(
     platform.system(), sys.version_info[0], sys.version_info[1],

--- a/tests/test_pickle_core.py
+++ b/tests/test_pickle_core.py
@@ -13,22 +13,20 @@
 # )
 import os
 import pickle
-from time import (
-    time,
-    sleep
-)
+import threading
 from datetime import timedelta
 from random import random
-import threading
+from time import sleep, time
 
 import pytest
 
 try:
     import queue
 except ImportError:  # python 2
-    import Queue as queue
+    import Queue as queue  # type: ignore
 
 import hashlib
+
 import pandas as pd
 
 from cachier import cachier
@@ -376,7 +374,7 @@ def _helper_bad_cache_file(sleeptime, separate_files):
     if not isinstance(res1, float):
         return False
     res2 = res_queue.get()
-    if not (res2 is None) or isinstance(res2, KeyError):
+    if res2 is not None or isinstance(res2, KeyError):
         return False
     return True
 

--- a/versioneer.py
+++ b/versioneer.py
@@ -349,10 +349,11 @@ https://creativecommons.org/publicdomain/zero/1.0/ .
 """
 
 from __future__ import print_function
+
 try:
     import configparser
 except ImportError:
-    import ConfigParser as configparser
+    import ConfigParser as configparser  # type: ignore
 import errno
 import json
 import os
@@ -1547,7 +1548,7 @@ def get_cmdclass():
     cmds["build_py"] = cmd_build_py
 
     if "cx_Freeze" in sys.modules:  # cx_freeze enabled?
-        from cx_Freeze.dist import build_exe as _build_exe
+        from cx_Freeze.dist import build_exe as _build_exe  # type: ignore[import]
 
         class cmd_build_exe(_build_exe):
             def run(self):


### PR DESCRIPTION
When using this module, I found myself looking up the docstring repeatedly to figure out what all the config options were

Turned out pretty easy to get the basics in - Mypy is not particularly strict here, but it now gives simple type hints & autocomplete in vscode

<img width="1013" alt="Screenshot 2023-06-20 at 00 07 08" src="https://github.com/python-cachier/cachier/assets/10530150/7d5602e6-cdaa-489f-8e14-2e68cb3e694b">

Adding generics on the decorator seems a lot harder, so I haven't bothered attempting that for now

