### PR TITLE
Make pymongo optional

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -15,3 +15,6 @@ exclude_lines =
 
     # Don't complain if tests don't hit defensive assertion code:
     raise NotImplementedError
+
+    # Is only true when running mypy, not tests
+    if TYPE_CHECKING:

--- a/cachier/core.py
+++ b/cachier/core.py
@@ -17,15 +17,17 @@ import os
 import pickle
 from concurrent.futures import ThreadPoolExecutor
 from functools import wraps
-from typing import Callable, Literal, Optional, TypedDict, Union
+from typing import TYPE_CHECKING, Callable, Literal, Optional, TypedDict, Union
 from warnings import warn
-
-from pymongo.collection import Collection
 
 from .base_core import RecalculationNeeded, _BaseCore
 from .memory_core import _MemoryCore
 from .mongo_core import _MongoCore
 from .pickle_core import _PickleCore
+
+if TYPE_CHECKING:
+    import pymongo.collection
+
 
 MAX_WORKERS_ENVAR_NAME = 'CACHIER_MAX_WORKERS'
 DEFAULT_MAX_WORKERS = 8
@@ -92,7 +94,7 @@ class MissingMongetter(ValueError):
 
 
 HashFunc = Callable[..., str]
-Mongetter = Callable[[], Collection]
+Mongetter = Callable[[], "pymongo.collection.Collection"]
 Backend = Literal["pickle", "mongo", "memory"]
 
 


### PR DESCRIPTION
Closes #125 

Currently, the way the `pymongo.collection.Collection` is imported, it makes it a hard requirement. Since it's only used for type checking, it's possible to guard this import with `if typing.TYPE_CHECKING:` and maintain existing functionality.

CC @kkaris