### PR TITLE
Order independent kwargs handling during cache key calculation

### DIFF
--- a/cachier/core.py
+++ b/cachier/core.py
@@ -15,6 +15,7 @@ import functools
 import hashlib
 import os
 import pickle
+from collections import OrderedDict
 from concurrent.futures import ThreadPoolExecutor
 from functools import wraps
 from typing import TYPE_CHECKING, Callable, Literal, Optional, TypedDict, Union
@@ -257,10 +258,11 @@ def cachier(
                 _print = print
             if ignore_cache or not _default_params['caching_enabled']:
                 return func(*args, **kwds)
+            kwds_ordered = OrderedDict(sorted(kwds.items()))
             if core.func_is_method:
-                key, entry = core.get_entry(args[1:], kwds)
+                key, entry = core.get_entry(args[1:], kwds_ordered)
             else:
-                key, entry = core.get_entry(args, kwds)
+                key, entry = core.get_entry(args, kwds_ordered)
             if overwrite_cache:
                 return _calc_entry(core, key, func, args, kwds)
             if entry is not None:  # pylint: disable=R0101

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -293,4 +293,3 @@ def test_order_independent_kwargs_handling():
     assert count == 1
     func(b=2, a=1)
     assert count == 1
-

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -275,3 +275,22 @@ def test_allow_caching_none():
     do_operation()
     do_operation()
     assert count == 1
+
+
+def test_order_independent_kwargs_handling():
+    count = 0
+
+    @cachier.cachier()
+    def func(a=None, b=None):
+        nonlocal count
+        count += 1
+        return 0
+
+    func.clear_cache()
+    assert count == 0
+    func(a=1, b=2)
+    func(a=1, b=2)
+    assert count == 1
+    func(b=2, a=1)
+    assert count == 1
+


### PR DESCRIPTION
Related to issue https://github.com/python-cachier/cachier/issues/132

Added sorting of kwargs so that changing the ordering will not invalidate the cache.
Added test for this feature.

Note: The keyword arguments are sorted only for cache key calculation. The actual function is still called with unordered arguments. The rationale for the latter is that if somebody is debugging their code then they might be confused if the arguments they see as their function input are in a different order than expected.