### PR TITLE
separate dev requirements from package extra

### DIFF
--- a/.github/workflows/checkdocs.yml
+++ b/.github/workflows/checkdocs.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e ".[test]"
+          python -m pip install -e . -r tests/requirements.txt
       - name: Check Docs
         run: |
           python setup.py checkdocs

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,7 +27,7 @@ jobs:
       # Install your linters here
       - name: Install linters
         run: |
-          python -m pip install -e ".[test]"
+          python -m pip install -e . -r tests/requirements.txt
 
       - name: Run linters
         uses: wearerequired/lint-action@v2.3.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e ".[test]"
+          python -m pip install -e . -r tests/requirements.txt
       - name: Unit tests
         env:
           CACHIER_TEST_HOST: ${{ secrets.CACHIER_TEST_HOST  }}

--- a/README.rst
+++ b/README.rst
@@ -363,7 +363,7 @@ Install in development mode with test dependencies:
 .. code-block:: bash
 
   cd cachier
-  pip install -e ".[test]"
+  pip install -e . -r tests/requirements.txt
 
 
 Running the tests

--- a/setup.py
+++ b/setup.py
@@ -14,21 +14,6 @@ except ImportError:
 
 import versioneer
 
-TEST_REQUIRES = [
-    # tests and coverages
-    'pytest', 'coverage', 'pytest-cov', 'birch',
-    # linting and code quality
-    'bandit', 'flake8', 'pylint', 'safety',
-    # type checking
-    'mypy', 'types-setuptools', 'pandas-stubs',
-    # to connect to the test mongodb server
-    'pymongo', 'dnspython', 'pymongo-inmemory',
-    # to test pandas dataframe as-param hashing with mongodb core
-    'pandas',
-    # to be able to run `python setup.py checkdocs`
-    'collective.checkdocs', 'pygments',
-]
-
 README_RST = ''
 with open('README.rst') as f:
     README_RST = f.read()
@@ -54,9 +39,6 @@ setup(
         'watchdog', 'portalocker',
         'setuptools>=67.6.0',  # to avoid vulnerability in 56.0.0
     ],
-    extras_require={
-        'test': TEST_REQUIRES,
-    },
     platforms=['linux', 'osx', 'windows'],
     keywords=['cache', 'persistence', 'mongo', 'memoization', 'decorator'],
     classifiers=[

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,24 @@
+# todo: add some version range or pinning latest versions
+# tests and coverages
+pytest
+coverage
+pytest-cov
+birch
+# linting and code quality; todo: remove after precommint lands
+bandit
+flake8
+pylint
+safety
+# type checking; todo: remove after precommint lands
+mypy
+types-setuptools
+pandas-stubs
+# to connect to the test mongodb server
+pymongo
+dnspython
+pymongo-inmemory
+# to test pandas dataframe as-param hashing with mongodb core
+pandas
+# to be able to run `python setup.py checkdocs`
+collective.checkdocs
+pygments


### PR DESCRIPTION
I may suggest simplifying the package dependencies as it does not need to have all development and testing packages append to this package which can be also by some tools and needed so they may flag this package for too wide many requirements...

cc: @shaypal5