### PR TITLE
ci: split tests for local / db

### DIFF
--- a/.github/workflows/checkdocs.yml
+++ b/.github/workflows/checkdocs.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e ".[test]"
+          python -m pip install -e . -r tests/requirements.txt
       - name: Check Docs
         run: |
           python setup.py checkdocs

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,7 +27,7 @@ jobs:
       # Install your linters here
       - name: Install linters
         run: |
-          python -m pip install -e ".[test]"
+          python -m pip install -e . -r tests/requirements.txt
 
       - name: Run linters
         uses: wearerequired/lint-action@v2.3.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,8 +16,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9, '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         os: [ubuntu-latest, macOS-latest, windows-latest]
+        backend: ['local', 'db']
 
     steps:
       - uses: actions/checkout@v3.4.0
@@ -31,15 +32,18 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -e ".[test]"
-      - name: Unit tests
+      - name: Unit tests (local)
+        if: matrix.backend == 'local'
+        run: pytest -m "NOT mongo"
+      - name: Unit tests (DB)
+        if: matrix.backend == 'db'
         env:
           CACHIER_TEST_HOST: ${{ secrets.CACHIER_TEST_HOST  }}
           CACHIER_TEST_DB: ${{ secrets.CACHIER_TEST_DB  }}
           CACHIER_TEST_USERNAME: ${{ secrets.CACHIER_TEST_USERNAME  }}
           CACHIER_TEST_PASSWORD: ${{ secrets.CACHIER_TEST_PASSWORD  }}
           CACHIER_TEST_VS_LIVE_MONGO: ${{ secrets.CACHIER_TEST_VS_LIVE_MONGO  }}
-        run: |
-          pytest
+        run: pytest -m "mongo"
       - name: "Upload coverage to Codecov"
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e ".[test]"
+          python -m pip install -e . -r tests/requirements.txt
       - name: Unit tests
         env:
           CACHIER_TEST_HOST: ${{ secrets.CACHIER_TEST_HOST  }}

--- a/README.rst
+++ b/README.rst
@@ -363,7 +363,7 @@ Install in development mode with test dependencies:
 .. code-block:: bash
 
   cd cachier
-  pip install -e ".[test]"
+  pip install -e . -r tests/requirements.txt
 
 
 Running the tests

--- a/setup.py
+++ b/setup.py
@@ -14,21 +14,6 @@ except ImportError:
 
 import versioneer
 
-TEST_REQUIRES = [
-    # tests and coverages
-    'pytest', 'coverage', 'pytest-cov', 'birch',
-    # linting and code quality
-    'bandit', 'flake8', 'pylint', 'safety',
-    # type checking
-    'mypy', 'types-setuptools', 'pandas-stubs',
-    # to connect to the test mongodb server
-    'pymongo', 'dnspython', 'pymongo-inmemory',
-    # to test pandas dataframe as-param hashing with mongodb core
-    'pandas',
-    # to be able to run `python setup.py checkdocs`
-    'collective.checkdocs', 'pygments',
-]
-
 README_RST = ''
 with open('README.rst') as f:
     README_RST = f.read()
@@ -54,9 +39,6 @@ setup(
         'watchdog', 'portalocker',
         'setuptools>=67.6.0',  # to avoid vulnerability in 56.0.0
     ],
-    extras_require={
-        'test': TEST_REQUIRES,
-    },
     platforms=['linux', 'osx', 'windows'],
     keywords=['cache', 'persistence', 'mongo', 'memoization', 'decorator'],
     classifiers=[

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,24 @@
+# todo: add some version range or pinning latest versions
+# tests and coverages
+pytest
+coverage
+pytest-cov
+birch
+# linting and code quality; todo: remove after precommint lands
+bandit
+flake8
+pylint
+safety
+# type checking; todo: remove after precommint lands
+mypy
+types-setuptools
+pandas-stubs
+# to connect to the test mongodb server
+pymongo
+dnspython
+pymongo-inmemory
+# to test pandas dataframe as-param hashing with mongodb core
+pandas
+# to be able to run `python setup.py checkdocs`
+collective.checkdocs
+pygments


### PR DESCRIPTION
Showing simple implementation suggested in https://github.com/python-cachier/cachier/pull/140#issuecomment-1921370683, which would split local tests and DB so it is easier to spot an issue since `local` shall pass always and `db` need to see credentials and that is why it does not pass forked PR