### PR TITLE
ci: reduce nb running jobs

### DIFF
--- a/.github/workflows/checkdocs.yml
+++ b/.github/workflows/checkdocs.yml
@@ -2,7 +2,9 @@ name: Check Docs
 
 on:
   pull_request:
+    branches: [master]
   push:
+    branches: [master]
 
 jobs:
   checkdocs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,10 @@
 name: Test
 
 on:
-  push:
   pull_request:
+    branches: [master]
+  push:
+    branches: [master]
   schedule:
     # * is a special character in YAML so you have to quote this string
     # min hours day(month) month day(week)


### PR DESCRIPTION
When there is created PR from the main repo, it runs two events, push to a beach and PR, which are basically the same jobs as linear history is required... so specify target branch will run jobs on master as it is puch to master and PR accordingly...
Effectively it runs half jobs harch notification event and faster iteration dues to limited number of agent for free projects :chipmunk: 