### PR TITLE
ci: set concurrency

### DIFF
--- a/.github/workflows/checkdocs.yml
+++ b/.github/workflows/checkdocs.yml
@@ -6,6 +6,10 @@ on:
   push:
     branches: [master]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
 jobs:
   checkdocs:
     runs-on: "ubuntu-latest"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,10 @@ on:
     # min hours day(month) month day(week)
     - cron: "0 0 * * 0"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
 jobs:
   pytester:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
as there are so many jobs/test running for each commit the CI with limited resources (with the free tier) become very soon saturated especially if there are frequent commit to an open PR... but in such case there is no need to run test on all commit but the last one... :rabbit: 

So this set concurrency such that all commits to mater are run fully and on a PR only the last one and if any previous is in action it will be canceled which will free resources :flamingo: 