### PR TITLE
Add a reference to the correct environment to pypi releaseflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,6 @@ jobs:
           name: cachier_dist
           path: dist
       - name: Publish distribution 📦 to PyPI
-        if: startsWith(github.event.ref, 'refs/tags') || github.event_name == 'release'
         uses: pypa/gh-action-pypi-publish@v1.8.11
         with:
           user: __token__

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,6 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
-    environment: pypi_publish
     env:
       RELEASING_PROCESS: "1"
     steps:
@@ -21,7 +20,6 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.x"
-
       - name: Install dependencies
         run: pip install -U build twine
       - name: Build package
@@ -38,6 +36,21 @@ jobs:
           files: "dist/*"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Upload dist artifact for the publish job
+        uses: actions/upload-artifact@master
+        with:
+          name: cachier_dist
+          path: dist
+
+  publish:
+    runs-on: ubuntu-latest
+    environment: pypi_publish
+    steps:
+      - name: Download dist artifact
+        uses: actions/download-artifact@master
+        with:
+          name: cachier_dist
+          path: dist
       - name: Publish distribution 📦 to PyPI
         if: startsWith(github.event.ref, 'refs/tags') || github.event_name == 'release'
         uses: pypa/gh-action-pypi-publish@v1.8.11

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,6 @@ name: PyPI Release
 on:
   push:
     branches: [master]
-  pull_request:
-    branches: [master]
   release:
     types: [published]
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,9 @@ jobs:
           path: dist
 
   publish:
+    needs: build
     runs-on: ubuntu-latest
+    if: startsWith(github.event.ref, 'refs/tags') || github.event_name == 'release'
     environment: pypi_publish
     steps:
       - name: Download dist artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,8 @@ name: PyPI Release
 on:
   push:
     branches: [master]
+  pull_request:
+    branches: [master]
   release:
     types: [published]
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
     environment: pypi_publish
     steps:
       - name: Download dist artifact
-        uses: actions/download-artifact@master
+        uses: actions/download-artifact@v4
         with:
           name: cachier_dist
           path: dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload dist artifact for the publish job
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v4
         with:
           name: cachier_dist
           path: dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    environment: pypi_publish
     env:
       RELEASING_PROCESS: "1"
     steps:


### PR DESCRIPTION
Hey, I'd love your help, @Borda .

I've set up a new dedicated Github Actions environment for this repository, named `pypi_publish`, which has a `PYPI_PASSWORD` secret with `cachier`'s PyPI API token.

However, from what I understand, a Github Actions environment is a job-level property:
https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment#using-an-environment

This seems a bit risky to me; a possible attack on PyPI secrets is now not only doing something fishy in the `gh-action-pypi-publish@v1.8.11` action, but also in any unrelated action we use earlier in the flow (in this case, `AButler/upload-release-assets@v3.0`).

So my question is, can you figure out a way to separate the PyPI upload step into a separate job in the same flow? Alternatively, is there a way to set up the environment for only a single step?

Cheers!