### PR TITLE
refactor: cleaning of using package/global defaults

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,10 +66,10 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.2.1
     hooks:
+      # use black formatting
+      - id: ruff-format
+        name: Black by Ruff
       # basic check
       - id: ruff
         name: Ruff check
         args: ["--fix"]
-      # use black formatting
-      - id: ruff-format
-        name: Black by Ruff

--- a/cachier/__init__.py
+++ b/cachier/__init__.py
@@ -1,12 +1,11 @@
+from ._version import *  # noqa: F403
 from .config import (
-    set_default_params,
-    get_default_params,
-    enable_caching,
     disable_caching,
+    enable_caching,
+    get_default_params,
+    set_default_params,
 )
 from .core import cachier
-
-from ._version import *  # noqa: F403
 
 __all__ = [
     "cachier",

--- a/cachier/__init__.py
+++ b/cachier/__init__.py
@@ -1,10 +1,10 @@
-from .core import (
-    cachier,
+from .config import (
     set_default_params,
     get_default_params,
     enable_caching,
     disable_caching,
 )
+from .core import cachier
 
 from ._version import *  # noqa: F403
 

--- a/cachier/_types.py
+++ b/cachier/_types.py
@@ -1,4 +1,4 @@
-from typing import Callable, TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Callable, Literal
 
 if TYPE_CHECKING:
     import pymongo.collection

--- a/cachier/_types.py
+++ b/cachier/_types.py
@@ -1,0 +1,9 @@
+from typing import Callable, TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    import pymongo.collection
+
+
+HashFunc = Callable[..., str]
+Mongetter = Callable[[], "pymongo.collection.Collection"]
+Backend = Literal["pickle", "mongo", "memory"]

--- a/cachier/config.py
+++ b/cachier/config.py
@@ -2,15 +2,9 @@ import datetime
 import hashlib
 import os
 import pickle
-from typing import Callable, Optional, Union, TypedDict, TYPE_CHECKING, Literal
+from typing import Optional, Union, TypedDict
 
-if TYPE_CHECKING:
-    import pymongo.collection
-
-
-_Type_HashFunc = Callable[..., str]
-_Type_Mongetter = Callable[[], "pymongo.collection.Collection"]
-_Type_Backend = Literal["pickle", "mongo", "memory"]
+from ._types import HashFunc, Backend, Mongetter
 
 
 def _default_hash_func(args, kwds):
@@ -24,9 +18,9 @@ def _default_hash_func(args, kwds):
 
 class Params(TypedDict):
     caching_enabled: bool
-    hash_func: _Type_HashFunc
-    backend: _Type_Backend
-    mongetter: Optional[_Type_Mongetter]
+    hash_func: HashFunc
+    backend: Backend
+    mongetter: Optional[Mongetter]
     stale_after: datetime.timedelta
     next_time: bool
     cache_dir: Union[str, os.PathLike]

--- a/cachier/config.py
+++ b/cachier/config.py
@@ -2,9 +2,9 @@ import datetime
 import hashlib
 import os
 import pickle
-from typing import Optional, Union, TypedDict
+from typing import Optional, TypedDict, Union
 
-from ._types import HashFunc, Backend, Mongetter
+from ._types import Backend, HashFunc, Mongetter
 
 
 def _default_hash_func(args, kwds):

--- a/cachier/config.py
+++ b/cachier/config.py
@@ -1,0 +1,90 @@
+import datetime
+import hashlib
+import os
+import pickle
+from typing import Callable, Optional, Union, TypedDict, TYPE_CHECKING
+from typing_extensions import Literal
+
+if TYPE_CHECKING:
+    import pymongo.collection
+
+
+_Type_HashFunc = Callable[..., str]
+_Type_Mongetter = Callable[[], "pymongo.collection.Collection"]
+_Type_Backend = Literal["pickle", "mongo", "memory"]
+
+
+def _default_hash_func(args, kwds):
+    # Sort the kwargs to ensure consistent ordering
+    sorted_kwargs = sorted(kwds.items())
+    # Serialize args and sorted_kwargs using pickle or similar
+    serialized = pickle.dumps((args, sorted_kwargs))
+    # Create a hash of the serialized data
+    return hashlib.sha256(serialized).hexdigest()
+
+
+class Params(TypedDict):
+    caching_enabled: bool
+    hash_func: _Type_HashFunc
+    backend: _Type_Backend
+    mongetter: Optional[_Type_Mongetter]
+    stale_after: datetime.timedelta
+    next_time: bool
+    cache_dir: Union[str, os.PathLike]
+    pickle_reload: bool
+    separate_files: bool
+    wait_for_calc_timeout: int
+    allow_none: bool
+
+
+_default_params: Params = {
+    "caching_enabled": True,
+    "hash_func": _default_hash_func,
+    "backend": "pickle",
+    "mongetter": None,
+    "stale_after": datetime.timedelta.max,
+    "next_time": False,
+    "cache_dir": "~/.cachier/",
+    "pickle_reload": True,
+    "separate_files": False,
+    "wait_for_calc_timeout": 0,
+    "allow_none": False,
+}
+
+
+def _update_with_defaults(param, name: str):
+    if param is None:
+        return _default_params[name]
+    return param
+
+
+def set_default_params(**params):
+    """Configure global parameters applicable to all memoized functions.
+
+    This function takes the same keyword parameters as the ones defined in the
+    decorator, which can be passed all at once or with multiple calls.
+    Parameters given directly to a decorator take precedence over any values
+    set by this function.
+
+    Only 'stale_after', 'next_time', and 'wait_for_calc_timeout' can be changed
+    after the memoization decorator has been applied. Other parameters will
+    only have an effect on decorators applied after this function is run.
+
+    """
+    valid_params = (p for p in params.items() if p[0] in _default_params)
+    _default_params.update(valid_params)
+
+
+def get_default_params():
+    """Get current set of default parameters."""
+    return _default_params
+
+
+def enable_caching():
+    """Enable caching globally."""
+    _default_params["caching_enabled"] = True
+
+
+def disable_caching():
+    """Disable caching globally."""
+    _default_params["caching_enabled"] = False

--- a/cachier/config.py
+++ b/cachier/config.py
@@ -46,9 +46,10 @@ _default_params: Params = {
 
 
 def _update_with_defaults(param, name: str):
-    nonlocal _default_params
+    import cachier
+
     if param is None:
-        return _default_params[name]
+        return cachier.config._default_params[name]
     return param
 
 
@@ -65,24 +66,30 @@ def set_default_params(**params):
     only have an effect on decorators applied after this function is run.
 
     """
-    nonlocal _default_params
-    valid_params = (p for p in params.items() if p[0] in _default_params)
+    import cachier
+
+    valid_params = (
+        p for p in params.items() if p[0] in cachier.config._default_params
+    )
     _default_params.update(valid_params)
 
 
 def get_default_params():
     """Get current set of default parameters."""
-    nonlocal _default_params
-    return _default_params
+    import cachier
+
+    return cachier.config._default_params
 
 
 def enable_caching():
     """Enable caching globally."""
-    nonlocal _default_params
-    _default_params["caching_enabled"] = True
+    import cachier
+
+    cachier.config._default_params["caching_enabled"] = True
 
 
 def disable_caching():
     """Disable caching globally."""
-    nonlocal _default_params
-    _default_params["caching_enabled"] = False
+    import cachier
+
+    cachier.config._default_params["caching_enabled"] = False

--- a/cachier/config.py
+++ b/cachier/config.py
@@ -2,8 +2,7 @@ import datetime
 import hashlib
 import os
 import pickle
-from typing import Callable, Optional, Union, TypedDict, TYPE_CHECKING
-from typing_extensions import Literal
+from typing import Callable, Optional, Union, TypedDict, TYPE_CHECKING, Literal
 
 if TYPE_CHECKING:
     import pymongo.collection

--- a/cachier/config.py
+++ b/cachier/config.py
@@ -46,7 +46,7 @@ _default_params: Params = {
 
 
 def _update_with_defaults(param, name: str):
-    global _default_params
+    nonlocal _default_params
     if param is None:
         return _default_params[name]
     return param
@@ -65,24 +65,24 @@ def set_default_params(**params):
     only have an effect on decorators applied after this function is run.
 
     """
-    global _default_params
+    nonlocal _default_params
     valid_params = (p for p in params.items() if p[0] in _default_params)
     _default_params.update(valid_params)
 
 
 def get_default_params():
     """Get current set of default parameters."""
-    global _default_params
+    nonlocal _default_params
     return _default_params
 
 
 def enable_caching():
     """Enable caching globally."""
-    global _default_params
+    nonlocal _default_params
     _default_params["caching_enabled"] = True
 
 
 def disable_caching():
     """Disable caching globally."""
-    global _default_params
+    nonlocal _default_params
     _default_params["caching_enabled"] = False

--- a/cachier/config.py
+++ b/cachier/config.py
@@ -46,6 +46,7 @@ _default_params: Params = {
 
 
 def _update_with_defaults(param, name: str):
+    global _default_params
     if param is None:
         return _default_params[name]
     return param
@@ -64,20 +65,24 @@ def set_default_params(**params):
     only have an effect on decorators applied after this function is run.
 
     """
+    global _default_params
     valid_params = (p for p in params.items() if p[0] in _default_params)
     _default_params.update(valid_params)
 
 
 def get_default_params():
     """Get current set of default parameters."""
+    global _default_params
     return _default_params
 
 
 def enable_caching():
     """Enable caching globally."""
+    global _default_params
     _default_params["caching_enabled"] = True
 
 
 def disable_caching():
     """Disable caching globally."""
+    global _default_params
     _default_params["caching_enabled"] = False

--- a/cachier/core.py
+++ b/cachier/core.py
@@ -7,26 +7,26 @@
 # http://www.opensource.org/licenses/MIT-license
 # Copyright (c) 2016, Shay Palachy <shaypal5@gmail.com>
 
-# python 2 compatibility
-
 import datetime
-import hashlib
 import inspect
 import os
-import pickle
 from collections import OrderedDict
 from concurrent.futures import ThreadPoolExecutor
 from functools import wraps
-from typing import TYPE_CHECKING, Callable, Literal, Optional, TypedDict, Union
+from typing import Optional, Union
 from warnings import warn
 
 from .cores.base import RecalculationNeeded, _BaseCore
 from .cores.memory import _MemoryCore
 from .cores.mongo import _MongoCore
 from .cores.pickle import _PickleCore
-
-if TYPE_CHECKING:
-    import pymongo.collection
+from .config import (
+    _Type_Mongetter,
+    _Type_HashFunc,
+    _Type_Backend,
+    _default_params,
+    _update_with_defaults,
+)
 
 
 MAX_WORKERS_ENVAR_NAME = "CACHIER_MAX_WORKERS"
@@ -68,15 +68,6 @@ def _calc_entry(core, key, func, args, kwds):
         core.mark_entry_not_calculated(key)
 
 
-def _default_hash_func(args, kwds):
-    # Sort the kwargs to ensure consistent ordering
-    sorted_kwargs = sorted(kwds.items())
-    # Serialize args and sorted_kwargs using pickle or similar
-    serialized = pickle.dumps((args, sorted_kwargs))
-    # Create a hash of the serialized data
-    return hashlib.sha256(serialized).hexdigest()
-
-
 def _convert_args_kwargs(
     func, _is_method: bool, args: tuple, kwds: dict
 ) -> dict:
@@ -103,49 +94,11 @@ def _convert_args_kwargs(
     return OrderedDict(sorted(kwargs.items()))
 
 
-class MissingMongetter(ValueError):
-    """Thrown when the mongetter keyword argument is missing."""
-
-
-HashFunc = Callable[..., str]
-Mongetter = Callable[[], "pymongo.collection.Collection"]
-Backend = Literal["pickle", "mongo", "memory"]
-
-
-class Params(TypedDict):
-    caching_enabled: bool
-    hash_func: HashFunc
-    backend: Backend
-    mongetter: Optional[Mongetter]
-    stale_after: datetime.timedelta
-    next_time: bool
-    cache_dir: Union[str, os.PathLike]
-    pickle_reload: bool
-    separate_files: bool
-    wait_for_calc_timeout: int
-    allow_none: bool
-
-
-_default_params: Params = {
-    "caching_enabled": True,
-    "hash_func": _default_hash_func,
-    "backend": "pickle",
-    "mongetter": None,
-    "stale_after": datetime.timedelta.max,
-    "next_time": False,
-    "cache_dir": "~/.cachier/",
-    "pickle_reload": True,
-    "separate_files": False,
-    "wait_for_calc_timeout": 0,
-    "allow_none": False,
-}
-
-
 def cachier(
-    hash_func: Optional[HashFunc] = None,
-    hash_params: Optional[HashFunc] = None,
-    backend: Optional[Backend] = None,
-    mongetter: Optional[Mongetter] = None,
+    hash_func: Optional[_Type_HashFunc] = None,
+    hash_params: Optional[_Type_HashFunc] = None,
+    backend: Optional[_Type_Backend] = None,
+    mongetter: Optional[_Type_Mongetter] = None,
     stale_after: Optional[datetime.timedelta] = None,
     next_time: Optional[bool] = None,
     cache_dir: Optional[Union[str, os.PathLike]] = None,
@@ -220,12 +173,17 @@ def cachier(
         warn(message, DeprecationWarning, stacklevel=2)
         hash_func = hash_params
     # Override the backend parameter if a mongetter is provided.
-    if mongetter is None:
-        mongetter = _default_params["mongetter"]
+    hash_func = _update_with_defaults(hash_func, "hash_func")
+    mongetter = _update_with_defaults(mongetter, "mongetter")
+    backend = _update_with_defaults(backend, "backend")
+    pickle_reload = _update_with_defaults(pickle_reload, "pickle_reload")
+    cache_dir = _update_with_defaults(cache_dir, "cache_dir")
+    separate_files = _update_with_defaults(separate_files, "separate_files")
+    wait_for_calc_timeout = _update_with_defaults(
+        wait_for_calc_timeout, "wait_for_calc_timeout"
+    )
     if callable(mongetter):
         backend = "mongo"
-    if backend is None:
-        backend = _default_params["backend"]
     core: _BaseCore
     if backend == "pickle":
         core = _PickleCore(
@@ -234,23 +192,16 @@ def cachier(
             cache_dir=cache_dir,
             separate_files=separate_files,
             wait_for_calc_timeout=wait_for_calc_timeout,
-            default_params=_default_params,
         )
     elif backend == "mongo":
-        if mongetter is None:
-            raise MissingMongetter(
-                "must specify ``mongetter`` when using the mongo core"
-            )
         core = _MongoCore(
             mongetter=mongetter,
             hash_func=hash_func,
             wait_for_calc_timeout=wait_for_calc_timeout,
-            default_params=_default_params,
         )
     elif backend == "memory":
         core = _MemoryCore(
-            hash_func=hash_func,
-            default_params=_default_params,
+            hash_func=hash_func, wait_for_calc_timeout=wait_for_calc_timeout
         )
     else:
         raise ValueError("specified an invalid core: %s" % backend)
@@ -261,11 +212,7 @@ def cachier(
         @wraps(func)
         def func_wrapper(*args, **kwds):
             nonlocal allow_none
-            _allow_none = (
-                allow_none
-                if allow_none is not None
-                else _default_params["allow_none"]
-            )
+            _allow_none = _update_with_defaults(allow_none, "allow_none")
             # print('Inside general wrapper for {}.'.format(func.__name__))
             ignore_cache = kwds.pop("ignore_cache", False)
             overwrite_cache = kwds.pop("overwrite_cache", False)
@@ -289,10 +236,10 @@ def cachier(
             _print("Entry found.")
             if _allow_none or entry.get("value", None) is not None:
                 _print("Cached result found.")
-                local_stale_after = (
-                    stale_after or _default_params["stale_after"]
+                local_stale_after = _update_with_defaults(
+                    stale_after, "stale_after"
                 )
-                local_next_time = next_time or _default_params["next_time"]  # noqa: E501
+                local_next_time = _update_with_defaults(next_time, "next_time")
                 now = datetime.datetime.now()
                 if now - entry["time"] <= local_stale_after:
                     _print("And it is fresh!")
@@ -362,35 +309,3 @@ def cachier(
         return func_wrapper
 
     return _cachier_decorator
-
-
-def set_default_params(**params):
-    """Configure global parameters applicable to all memoized functions.
-
-    This function takes the same keyword parameters as the ones defined in the
-    decorator, which can be passed all at once or with multiple calls.
-    Parameters given directly to a decorator take precedence over any values
-    set by this function.
-
-    Only 'stale_after', 'next_time', and 'wait_for_calc_timeout' can be changed
-    after the memoization decorator has been applied. Other parameters will
-    only have an effect on decorators applied after this function is run.
-
-    """
-    valid_params = (p for p in params.items() if p[0] in _default_params)
-    _default_params.update(valid_params)
-
-
-def get_default_params():
-    """Get current set of default parameters."""
-    return _default_params
-
-
-def enable_caching():
-    """Enable caching globally."""
-    _default_params["caching_enabled"] = True
-
-
-def disable_caching():
-    """Disable caching globally."""
-    _default_params["caching_enabled"] = False

--- a/cachier/core.py
+++ b/cachier/core.py
@@ -172,15 +172,7 @@ def cachier(
         warn(message, DeprecationWarning, stacklevel=2)
         hash_func = hash_params
     # Update parameters with defaults if input is None
-    hash_func = _update_with_defaults(hash_func, "hash_func")
-    mongetter = _update_with_defaults(mongetter, "mongetter")
     backend = _update_with_defaults(backend, "backend")
-    pickle_reload = _update_with_defaults(pickle_reload, "pickle_reload")
-    cache_dir = _update_with_defaults(cache_dir, "cache_dir")
-    separate_files = _update_with_defaults(separate_files, "separate_files")
-    wait_for_calc_timeout = _update_with_defaults(
-        wait_for_calc_timeout, "wait_for_calc_timeout"
-    )
     # Override the backend parameter if a mongetter is provided.
     if callable(mongetter):
         backend = "mongo"

--- a/cachier/core.py
+++ b/cachier/core.py
@@ -187,8 +187,8 @@ def cachier(
         )
     elif backend == "mongo":
         core = _MongoCore(
-            mongetter=mongetter,
             hash_func=hash_func,
+            mongetter=mongetter,
             wait_for_calc_timeout=wait_for_calc_timeout,
         )
     elif backend == "memory":

--- a/cachier/core.py
+++ b/cachier/core.py
@@ -21,9 +21,9 @@ from .cores.memory import _MemoryCore
 from .cores.mongo import _MongoCore
 from .cores.pickle import _PickleCore
 from .config import (
-    _Type_Mongetter,
-    _Type_HashFunc,
-    _Type_Backend,
+    Mongetter,
+    HashFunc,
+    Backend,
     _default_params,
     _update_with_defaults,
 )
@@ -95,10 +95,10 @@ def _convert_args_kwargs(
 
 
 def cachier(
-    hash_func: Optional[_Type_HashFunc] = None,
-    hash_params: Optional[_Type_HashFunc] = None,
-    backend: Optional[_Type_Backend] = None,
-    mongetter: Optional[_Type_Mongetter] = None,
+    hash_func: Optional[HashFunc] = None,
+    hash_params: Optional[HashFunc] = None,
+    backend: Optional[Backend] = None,
+    mongetter: Optional[Mongetter] = None,
     stale_after: Optional[datetime.timedelta] = None,
     next_time: Optional[bool] = None,
     cache_dir: Optional[Union[str, os.PathLike]] = None,

--- a/cachier/core.py
+++ b/cachier/core.py
@@ -16,18 +16,17 @@ from functools import wraps
 from typing import Optional, Union
 from warnings import warn
 
+from .config import (
+    Backend,
+    HashFunc,
+    Mongetter,
+    _default_params,
+    _update_with_defaults,
+)
 from .cores.base import RecalculationNeeded, _BaseCore
 from .cores.memory import _MemoryCore
 from .cores.mongo import _MongoCore
 from .cores.pickle import _PickleCore
-from .config import (
-    Mongetter,
-    HashFunc,
-    Backend,
-    _default_params,
-    _update_with_defaults,
-)
-
 
 MAX_WORKERS_ENVAR_NAME = "CACHIER_MAX_WORKERS"
 DEFAULT_MAX_WORKERS = 8

--- a/cachier/core.py
+++ b/cachier/core.py
@@ -172,7 +172,7 @@ def cachier(
         )
         warn(message, DeprecationWarning, stacklevel=2)
         hash_func = hash_params
-    # Override the backend parameter if a mongetter is provided.
+    # Update parameters with defaults if input is None
     hash_func = _update_with_defaults(hash_func, "hash_func")
     mongetter = _update_with_defaults(mongetter, "mongetter")
     backend = _update_with_defaults(backend, "backend")
@@ -182,6 +182,7 @@ def cachier(
     wait_for_calc_timeout = _update_with_defaults(
         wait_for_calc_timeout, "wait_for_calc_timeout"
     )
+    # Override the backend parameter if a mongetter is provided.
     if callable(mongetter):
         backend = "mongo"
     core: _BaseCore

--- a/cachier/core.py
+++ b/cachier/core.py
@@ -173,6 +173,7 @@ def cachier(
         hash_func = hash_params
     # Update parameters with defaults if input is None
     backend = _update_with_defaults(backend, "backend")
+    mongetter = _update_with_defaults(mongetter, "mongetter")
     # Override the backend parameter if a mongetter is provided.
     if callable(mongetter):
         backend = "mongo"

--- a/cachier/cores/base.py
+++ b/cachier/cores/base.py
@@ -9,7 +9,7 @@
 import abc  # for the _BaseCore abstract base class
 import inspect
 
-from ..config import _Type_HashFunc
+from .._types import HashFunc
 
 
 class RecalculationNeeded(Exception):
@@ -19,7 +19,7 @@ class RecalculationNeeded(Exception):
 class _BaseCore:
     __metaclass__ = abc.ABCMeta
 
-    def __init__(self, hash_func: _Type_HashFunc, wait_for_calc_timeout: int):
+    def __init__(self, hash_func: HashFunc, wait_for_calc_timeout: int):
         self.hash_func = hash_func
         self.wait_for_calc_timeout = wait_for_calc_timeout
 

--- a/cachier/cores/base.py
+++ b/cachier/cores/base.py
@@ -8,8 +8,10 @@
 
 import abc  # for the _BaseCore abstract base class
 import inspect
+import threading
 
 from .._types import HashFunc
+from ..config import _update_with_defaults
 
 
 class RecalculationNeeded(Exception):
@@ -20,8 +22,9 @@ class _BaseCore:
     __metaclass__ = abc.ABCMeta
 
     def __init__(self, hash_func: HashFunc, wait_for_calc_timeout: int):
-        self.hash_func = hash_func
+        self.hash_func = _update_with_defaults(hash_func, "hash_func")
         self.wait_for_calc_timeout = wait_for_calc_timeout
+        self.lock = threading.RLock()
 
     def set_func(self, func):
         """Sets the function this core will use.
@@ -55,7 +58,9 @@ class _BaseCore:
 
     def check_calc_timeout(self, time_spent):
         """Raise an exception if a recalculation is needed."""
-        calc_timeout = self.wait_for_calc_timeout
+        calc_timeout = _update_with_defaults(
+            self.wait_for_calc_timeout, "wait_for_calc_timeout"
+        )
         if calc_timeout > 0 and (time_spent >= calc_timeout):
             raise RecalculationNeeded()
 

--- a/cachier/cores/base.py
+++ b/cachier/cores/base.py
@@ -9,6 +9,8 @@
 import abc  # for the _BaseCore abstract base class
 import inspect
 
+from ..config import _Type_HashFunc
+
 
 class RecalculationNeeded(Exception):
     pass
@@ -17,9 +19,9 @@ class RecalculationNeeded(Exception):
 class _BaseCore:
     __metaclass__ = abc.ABCMeta
 
-    def __init__(self, hash_func, default_params):
-        self.default_params = default_params
+    def __init__(self, hash_func: _Type_HashFunc, wait_for_calc_timeout: int):
         self.hash_func = hash_func
+        self.wait_for_calc_timeout = wait_for_calc_timeout
 
     def set_func(self, func):
         """Sets the function this core will use.
@@ -37,10 +39,7 @@ class _BaseCore:
 
     def get_key(self, args, kwds):
         """Returns a unique key based on the arguments provided."""
-        if self.hash_func is not None:
-            return self.hash_func(args, kwds)
-        else:
-            return self.default_params["hash_func"](args, kwds)
+        return self.hash_func(args, kwds)
 
     def get_entry(self, args, kwds):
         """Returns the result mapped to the given arguments in this core's
@@ -56,10 +55,7 @@ class _BaseCore:
 
     def check_calc_timeout(self, time_spent):
         """Raise an exception if a recalculation is needed."""
-        if self.wait_for_calc_timeout is not None:
-            calc_timeout = self.wait_for_calc_timeout
-        else:
-            calc_timeout = self.default_params["wait_for_calc_timeout"]
+        calc_timeout = self.wait_for_calc_timeout
         if calc_timeout > 0 and (time_spent >= calc_timeout):
             raise RecalculationNeeded()
 

--- a/cachier/cores/memory.py
+++ b/cachier/cores/memory.py
@@ -3,8 +3,8 @@
 import threading
 from datetime import datetime
 
-from .base import _BaseCore
 from .._types import HashFunc
+from .base import _BaseCore
 
 
 class _MemoryCore(_BaseCore):

--- a/cachier/cores/memory.py
+++ b/cachier/cores/memory.py
@@ -4,13 +4,14 @@ import threading
 from datetime import datetime
 
 from .base import _BaseCore
+from ..config import _Type_HashFunc
 
 
 class _MemoryCore(_BaseCore):
     """The memory core class for cachier."""
 
-    def __init__(self, hash_func, default_params):
-        super().__init__(hash_func, default_params)
+    def __init__(self, hash_func: _Type_HashFunc, wait_for_calc_timeout: int):
+        super().__init__(hash_func, wait_for_calc_timeout)
         self.cache = {}
         self.lock = threading.RLock()
 

--- a/cachier/cores/memory.py
+++ b/cachier/cores/memory.py
@@ -13,7 +13,6 @@ class _MemoryCore(_BaseCore):
     def __init__(self, hash_func: HashFunc, wait_for_calc_timeout: int):
         super().__init__(hash_func, wait_for_calc_timeout)
         self.cache = {}
-        self.lock = threading.RLock()
 
     def get_entry_by_key(self, key, reload=False):
         with self.lock:

--- a/cachier/cores/memory.py
+++ b/cachier/cores/memory.py
@@ -4,13 +4,13 @@ import threading
 from datetime import datetime
 
 from .base import _BaseCore
-from ..config import _Type_HashFunc
+from .._types import HashFunc
 
 
 class _MemoryCore(_BaseCore):
     """The memory core class for cachier."""
 
-    def __init__(self, hash_func: _Type_HashFunc, wait_for_calc_timeout: int):
+    def __init__(self, hash_func: HashFunc, wait_for_calc_timeout: int):
         super().__init__(hash_func, wait_for_calc_timeout)
         self.cache = {}
         self.lock = threading.RLock()

--- a/cachier/cores/mongo.py
+++ b/cachier/cores/mongo.py
@@ -15,7 +15,6 @@ from contextlib import suppress
 from datetime import datetime
 
 from .._types import HashFunc, Mongetter
-from ..config import _update_with_defaults
 
 with suppress(ImportError):
     from bson.binary import Binary  # to save binary data to mongodb
@@ -46,12 +45,12 @@ class _MongoCore(_BaseCore):
                 "MongoDB cores will not function."
             )  # pragma: no cover
 
-        self.mongetter = _update_with_defaults(mongetter, "mongetter")
+        super().__init__(hash_func, wait_for_calc_timeout)
         if mongetter is None:
             raise MissingMongetter(
                 "must specify ``mongetter`` when using the mongo core"
             )
-        super().__init__(hash_func, wait_for_calc_timeout)
+        self.mongetter = mongetter
         self.mongo_collection = self.mongetter()
         index_inf = self.mongo_collection.index_information()
         if _MongoCore._INDEX_NAME not in index_inf:

--- a/cachier/cores/mongo.py
+++ b/cachier/cores/mongo.py
@@ -15,6 +15,7 @@ from contextlib import suppress
 from datetime import datetime
 
 from .._types import HashFunc, Mongetter
+from ..config import _update_with_defaults
 
 with suppress(ImportError):
     from bson.binary import Binary  # to save binary data to mongodb
@@ -35,8 +36,8 @@ class _MongoCore(_BaseCore):
 
     def __init__(
         self,
-        mongetter: Mongetter,
         hash_func: HashFunc,
+        mongetter: Mongetter,
         wait_for_calc_timeout: int,
     ):
         if "pymongo" not in sys.modules:
@@ -50,7 +51,7 @@ class _MongoCore(_BaseCore):
                 "must specify ``mongetter`` when using the mongo core"
             )
         super().__init__(hash_func, wait_for_calc_timeout)
-        self.mongetter = mongetter
+        self.mongetter = _update_with_defaults(mongetter, "mongetter")
         self.mongo_collection = self.mongetter()
         index_inf = self.mongo_collection.index_information()
         if _MongoCore._INDEX_NAME not in index_inf:

--- a/cachier/cores/mongo.py
+++ b/cachier/cores/mongo.py
@@ -7,21 +7,21 @@
 # http://www.opensource.org/licenses/MIT-license
 # Copyright (c) 2016, Shay Palachy <shaypal5@gmail.com>
 
-import sys  # to make sure that pymongo was imported
 import pickle  # for serialization of python objects
-from contextlib import suppress
-from datetime import datetime
+import sys  # to make sure that pymongo was imported
 import time  # to sleep when waiting on Mongo cache\
 import warnings  # to warn if pymongo is missing
+from contextlib import suppress
+from datetime import datetime
+
 from .._types import HashFunc, Mongetter
 
 with suppress(ImportError):
-    from pymongo import IndexModel, ASCENDING
-    from pymongo.errors import OperationFailure
     from bson.binary import Binary  # to save binary data to mongodb
+    from pymongo import ASCENDING, IndexModel
+    from pymongo.errors import OperationFailure
 
-from .base import _BaseCore, RecalculationNeeded
-
+from .base import RecalculationNeeded, _BaseCore
 
 MONGO_SLEEP_DURATION_IN_SEC = 1
 

--- a/cachier/cores/mongo.py
+++ b/cachier/cores/mongo.py
@@ -13,7 +13,7 @@ from contextlib import suppress
 from datetime import datetime
 import time  # to sleep when waiting on Mongo cache\
 import warnings  # to warn if pymongo is missing
-from ..config import _Type_HashFunc, _Type_Mongetter
+from .._types import HashFunc, Mongetter
 
 with suppress(ImportError):
     from pymongo import IndexModel, ASCENDING
@@ -35,8 +35,8 @@ class _MongoCore(_BaseCore):
 
     def __init__(
         self,
-        mongetter: _Type_Mongetter,
-        hash_func: _Type_HashFunc,
+        mongetter: Mongetter,
+        hash_func: HashFunc,
         wait_for_calc_timeout: int,
     ):
         if "pymongo" not in sys.modules:

--- a/cachier/cores/mongo.py
+++ b/cachier/cores/mongo.py
@@ -46,12 +46,12 @@ class _MongoCore(_BaseCore):
                 "MongoDB cores will not function."
             )  # pragma: no cover
 
+        self.mongetter = _update_with_defaults(mongetter, "mongetter")
         if mongetter is None:
             raise MissingMongetter(
                 "must specify ``mongetter`` when using the mongo core"
             )
         super().__init__(hash_func, wait_for_calc_timeout)
-        self.mongetter = _update_with_defaults(mongetter, "mongetter")
         self.mongo_collection = self.mongetter()
         index_inf = self.mongo_collection.index_information()
         if _MongoCore._INDEX_NAME not in index_inf:

--- a/cachier/cores/pickle.py
+++ b/cachier/cores/pickle.py
@@ -8,7 +8,6 @@
 # Copyright (c) 2016, Shay Palachy <shaypal5@gmail.com>
 import os
 import pickle  # for local caching
-import threading
 from contextlib import suppress
 from datetime import datetime
 
@@ -17,6 +16,7 @@ from watchdog.events import PatternMatchingEventHandler
 from watchdog.observers import Observer
 
 from .._types import HashFunc
+from ..config import _update_with_defaults
 
 # Alternative:  https://github.com/WoLpH/portalocker
 from .base import _BaseCore
@@ -79,12 +79,15 @@ class _PickleCore(_BaseCore):
     ):
         super().__init__(hash_func, wait_for_calc_timeout)
         self.cache = None
-        self.reload = pickle_reload
-        self.cache_dir = os.path.expanduser(cache_dir)
-        self.separate_files = separate_files
+        self.reload = _update_with_defaults(pickle_reload, "pickle_reload")
+        self.cache_dir = os.path.expanduser(
+            _update_with_defaults(cache_dir, "cache_dir")
+        )
+        self.separate_files = _update_with_defaults(
+            separate_files, "separate_files"
+        )
         self.cache_fname = None
         self.cache_fpath = None
-        self.lock = threading.RLock()
 
     def _cache_fname(self):
         if self.cache_fname is None:

--- a/cachier/cores/pickle.py
+++ b/cachier/cores/pickle.py
@@ -19,7 +19,7 @@ from watchdog.events import PatternMatchingEventHandler
 # Alternative:  https://github.com/WoLpH/portalocker
 
 from .base import _BaseCore
-from ..config import _Type_HashFunc
+from .._types import HashFunc
 
 
 class _PickleCore(_BaseCore):
@@ -71,7 +71,7 @@ class _PickleCore(_BaseCore):
 
     def __init__(
         self,
-        hash_func: _Type_HashFunc,
+        hash_func: HashFunc,
         pickle_reload: bool,
         cache_dir: str,
         separate_files: bool,

--- a/cachier/cores/pickle.py
+++ b/cachier/cores/pickle.py
@@ -88,22 +88,16 @@ class _PickleCore(_BaseCore):
 
     def _cache_fname(self):
         if self.cache_fname is None:
-            self.cache_fname = (
-                f".{self.func.__module__}.{self.func.__qualname__}"
-            )
-            self.cache_fname = self.cache_fname.replace("<", "_").replace(
-                ">", "_"
-            )
+            fname = f".{self.func.__module__}.{self.func.__qualname__}"
+            self.cache_fname = fname.replace("<", "_").replace(">", "_")
         return self.cache_fname
 
     def _cache_fpath(self):
         if self.cache_fpath is None:
-            if not os.path.exists(self.cache_dir):
-                os.makedirs(self.cache_dir)
+            os.makedirs(self.cache_dir, exist_ok=True)
             self.cache_fpath = os.path.abspath(
                 os.path.join(
-                    os.path.realpath(self.cache_dir),
-                    self._cache_fname(),
+                    os.path.realpath(self.cache_dir), self._cache_fname()
                 )
             )
         return self.cache_fpath

--- a/cachier/cores/pickle.py
+++ b/cachier/cores/pickle.py
@@ -19,19 +19,11 @@ from watchdog.events import PatternMatchingEventHandler
 # Alternative:  https://github.com/WoLpH/portalocker
 
 from .base import _BaseCore
+from ..config import _Type_HashFunc
 
 
 class _PickleCore(_BaseCore):
-    """The pickle core class for cachier.
-
-    Parameters
-    ----------
-    pickle_reload : bool, optional
-        See core.cachier() documentation.
-    cache_dir : str, optional.
-        See core.cachier() documentation.
-
-    """
+    """The pickle core class for cachier."""
 
     class CacheChangeHandler(PatternMatchingEventHandler):
         """Handles cache-file modification events."""
@@ -79,36 +71,23 @@ class _PickleCore(_BaseCore):
 
     def __init__(
         self,
-        hash_func,
-        pickle_reload,
-        cache_dir,
-        separate_files,
-        wait_for_calc_timeout,
-        default_params,
+        hash_func: _Type_HashFunc,
+        pickle_reload: bool,
+        cache_dir: str,
+        separate_files: bool,
+        wait_for_calc_timeout: int,
     ):
-        super().__init__(hash_func, default_params)
+        super().__init__(hash_func, wait_for_calc_timeout)
         self.cache = None
-        if pickle_reload is not None:
-            self.reload = pickle_reload
-        else:
-            self.reload = self.default_params["pickle_reload"]
-        if cache_dir is not None:
-            self.cache_dir = os.path.expanduser(cache_dir)
-        else:
-            self.cache_dir = os.path.expanduser(
-                self.default_params["cache_dir"]
-            )
-        if separate_files is not None:
-            self.separate_files = separate_files
-        else:
-            self.separate_files = self.default_params["separate_files"]
-        self.wait_for_calc_timeout = wait_for_calc_timeout
+        self.reload = pickle_reload
+        self.cache_dir = os.path.expanduser(cache_dir)
+        self.separate_files = separate_files
         self.cache_fname = None
         self.cache_fpath = None
         self.lock = threading.RLock()
 
     def _cache_fname(self):
-        if self.cache_fname is None:
+        if self.cache_fname is not None:
             self.cache_fname = (
                 f".{self.func.__module__}.{self.func.__qualname__}"
             )

--- a/cachier/cores/pickle.py
+++ b/cachier/cores/pickle.py
@@ -87,7 +87,7 @@ class _PickleCore(_BaseCore):
         self.lock = threading.RLock()
 
     def _cache_fname(self):
-        if self.cache_fname is not None:
+        if self.cache_fname is None:
             self.cache_fname = (
                 f".{self.func.__module__}.{self.func.__qualname__}"
             )

--- a/cachier/cores/pickle.py
+++ b/cachier/cores/pickle.py
@@ -16,9 +16,10 @@ import portalocker  # to lock on pickle cache IO
 from watchdog.events import PatternMatchingEventHandler
 from watchdog.observers import Observer
 
+from .._types import HashFunc
+
 # Alternative:  https://github.com/WoLpH/portalocker
 from .base import _BaseCore
-from .._types import HashFunc
 
 
 class _PickleCore(_BaseCore):

--- a/tests/test_core_lookup.py
+++ b/tests/test_core_lookup.py
@@ -2,7 +2,7 @@
 import pytest
 
 from cachier import cachier, get_default_params
-from cachier.core import MissingMongetter
+from cachier.cores.mongo import MissingMongetter
 
 
 def test_get_default_params():

--- a/tests/test_mongo_core.py
+++ b/tests/test_mongo_core.py
@@ -268,7 +268,7 @@ def test_stalled_mongo_db_cache():
     def _stalled_func():
         return 1
 
-    core = _MongoCore(_test_mongetter, None, 0, {})
+    core = _MongoCore(_test_mongetter, None, 0)
     core.set_func(_stalled_func)
     core.clear_cache()
     with pytest.raises(RecalculationNeeded):

--- a/tests/test_mongo_core.py
+++ b/tests/test_mongo_core.py
@@ -267,7 +267,7 @@ def test_stalled_mongo_db_cache():
     def _stalled_func():
         return 1
 
-    core = _MongoCore(_test_mongetter, None, 0)
+    core = _MongoCore(None, _test_mongetter, 0)
     core.set_func(_stalled_func)
     core.clear_cache()
     with pytest.raises(RecalculationNeeded):


### PR DESCRIPTION
While Working on the package, I found the default challenging to follow... I go that package want to have one global setting but as dist it hard to trace and eventually help with refactor by any IDE, so using `dataclass` would be better.

Also, for user, I think using default directly with the `cashier` would be much better, see additional suggestion
```py
def cachier(
    hash_func: _Type_HashFunc = _default_hash_func,
    hash_params: Optional[_Type_HashFunc] = None,
    backend: _Type_Backend = "pickle",
    mongetter: Optional[_Type_Mongetter] = None,
    stale_after: datetime.timedelta = datetime.timedelta.max,
    next_time: bool = False,
    cache_dir: Union[str, os.PathLike] = "~/.cachier/",
    pickle_reload: bool = True,
    separate_files: bool = False,
    wait_for_calc_timeout: int = 0,
    allow_none: bool = False,
):
    ...
```