### PR TITLE
fix: redefine partial kwargs

### DIFF
--- a/cachier/core.py
+++ b/cachier/core.py
@@ -75,7 +75,7 @@ def _convert_args_kwargs(
     # unwrap if the function is functools.partial
     if hasattr(func, "func"):
         args = func.args + args
-        kwds = dict(**func.keywords, **kwds)
+        kwds.update({k: v for k, v in func.keywords.items() if k not in kwds})
         func = func.func
     func_params = list(inspect.signature(func).parameters)
     args_as_kw = dict(

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -402,11 +402,17 @@ def test_partial_handling(tmpdir):
         dummy_ = functools.partial(fn, 1)
         assert cachier_(dummy_)() == expected
 
+        dummy_ = functools.partial(fn, 1)
+        assert cachier_(dummy_)(2) == expected
+
         dummy_ = functools.partial(fn, a=1)
         assert cachier_(dummy_)() == expected
 
         dummy_ = functools.partial(fn, b=2)
         assert cachier_(dummy_)(1) == expected
+
+        dummy_ = functools.partial(fn, b=2)
+        assert cachier_(dummy_)(1, b=2) == expected
 
         assert cachier_(fn)(1, 2) == expected
         assert cachier_(fn)(a=1, b=2) == expected


### PR DESCRIPTION
When partial is used and both partial and called func have the same kwargs