### PR TITLE
precommit: add `mdformat` & drop `pyupgrade`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,14 +22,6 @@ repos:
       - id: check-added-large-files
       - id: detect-private-key
 
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.0
-    hooks:
-      - id: pyupgrade
-        args: ["--py38-plus"]
-        name: Upgrade code
-        exclude: versioneer.py
-
   - repo: https://github.com/crate-ci/typos
     rev: typos-v0.10.21
     hooks:
@@ -44,10 +36,21 @@ repos:
         additional_dependencies: [tomli]
         args: ["--in-place"]
 
+  - repo: https://github.com/executablebooks/mdformat
+    rev: 0.7.17
+    hooks:
+      - id: mdformat
+        additional_dependencies:
+          - mdformat-gfm
+          - mdformat-black
+          - mdformat_frontmatter
+        args: ["--number"]
+
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v3.1.0
     hooks:
       - id: prettier
+        files: \.(json|yml|yaml|toml)
         # https://prettier.io/docs/en/options.html#print-width
         args: ["--print-width=79"]
 


### PR DESCRIPTION
`pyupgrade` is already included in `RUF100` and adding MD linter