### PR TITLE
Fix __main__ typo in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
   "watchdog>=2.3.1",
 ]
 urls.Source = "https://github.com/python-cachier/cachier"
-scripts.cachier = "cachier.__naim__:cli"
+scripts.cachier = "cachier.__main__:cli"
 
 [tool.setuptools]
 include-package-data = true


### PR DESCRIPTION
Fixes the `__naim__` typo in the script definition that should be `__main__`

This was causing

```
ModuleNotFoundError: No module named 'cachier.__naim__'
```

After the fix the cli will work:

```
$ cachier --help
Usage: cachier [OPTIONS] COMMAND [ARGS]...

  A command-line interface for cachier.

Options:
  --help  Show this message and exit.

Commands:
  Limits the number of worker threads used by cachier.
                                  Limits the number...

$ cachier "Limits the number of worker threads used by cachier." 10
```