### PR TITLE
convert `_default_params` to dataclass

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,7 +47,7 @@ repos:
         args: ["--number"]
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v4.0.0-alpha.8
+    rev: v3.1.0
     hooks:
       - id: prettier
         files: \.(json|yml|yaml|toml)

--- a/src/cachier/__init__.py
+++ b/src/cachier/__init__.py
@@ -2,15 +2,15 @@ from ._version import *  # noqa: F403
 from .config import (
     disable_caching,
     enable_caching,
-    get_default_params,
-    set_default_params,
+    get_global_params,
+    set_global_params,
 )
 from .core import cachier
 
 __all__ = [
     "cachier",
-    "set_default_params",
-    "get_default_params",
+    "set_global_params",
+    "get_global_params",
     "enable_caching",
     "disable_caching",
 ]

--- a/src/cachier/config.py
+++ b/src/cachier/config.py
@@ -20,34 +20,22 @@ def _default_hash_func(args, kwds):
 
 @dataclass
 class Params:
-    """Type definition for cachier parameters."""
+    """Default definition for cachier parameters."""
 
-    caching_enabled: bool
-    hash_func: HashFunc
-    backend: Backend
-    mongetter: Optional[Mongetter]
-    stale_after: datetime.timedelta
-    next_time: bool
-    cache_dir: Union[str, os.PathLike]
-    pickle_reload: bool
-    separate_files: bool
-    wait_for_calc_timeout: int
-    allow_none: bool
+    caching_enabled: bool = True
+    hash_func: HashFunc = _default_hash_func
+    backend: Backend = "pickle"
+    mongetter: Optional[Mongetter] = None
+    stale_after: datetime.timedelta = datetime.timedelta.max
+    next_time: bool = False
+    cache_dir: Union[str, os.PathLike] = "~/.cachier/"
+    pickle_reload: bool = True
+    separate_files: bool = False
+    wait_for_calc_timeout: int = 0
+    allow_none: bool = False
 
 
-_default_params = Params(
-    caching_enabled=True,
-    hash_func=_default_hash_func,
-    backend="pickle",
-    mongetter=None,
-    stale_after=datetime.timedelta.max,
-    next_time=False,
-    cache_dir="~/.cachier/",
-    pickle_reload=True,
-    separate_files=False,
-    wait_for_calc_timeout=0,
-    allow_none=False,
-)
+_global_params = Params()
 
 
 def _update_with_defaults(
@@ -60,7 +48,7 @@ def _update_with_defaults(
         if kw_name in func_kwargs:
             return func_kwargs.pop(kw_name)
     if param is None:
-        return getattr(cachier.config._default_params, name)
+        return getattr(cachier.config._global_params, name)
     return param
 
 
@@ -82,10 +70,10 @@ def set_default_params(**params: Mapping) -> None:
     valid_params = {
         k: v
         for k, v in params.items()
-        if hasattr(cachier.config._default_params, k)
+        if hasattr(cachier.config._global_params, k)
     }
-    cachier.config._default_params = replace(
-        cachier.config._default_params, **valid_params
+    cachier.config._global_params = replace(
+        cachier.config._global_params, **valid_params
     )
 
 
@@ -93,18 +81,18 @@ def get_default_params() -> Params:
     """Get current set of default parameters."""
     import cachier
 
-    return cachier.config._default_params
+    return cachier.config._global_params
 
 
 def enable_caching():
     """Enable caching globally."""
     import cachier
 
-    cachier.config._default_params.caching_enabled = True
+    cachier.config._global_params.caching_enabled = True
 
 
 def disable_caching():
     """Disable caching globally."""
     import cachier
 
-    cachier.config._default_params.caching_enabled = False
+    cachier.config._global_params.caching_enabled = False

--- a/src/cachier/config.py
+++ b/src/cachier/config.py
@@ -2,6 +2,7 @@ import datetime
 import hashlib
 import os
 import pickle
+from collections.abc import Mapping
 from dataclasses import dataclass, replace
 from typing import Optional, Union
 
@@ -63,7 +64,7 @@ def _update_with_defaults(
     return param
 
 
-def set_default_params(**params):
+def set_default_params(**params: Mapping) -> None:
     """Configure global parameters applicable to all memoized functions.
 
     This function takes the same keyword parameters as the ones defined in the
@@ -78,15 +79,17 @@ def set_default_params(**params):
     """
     import cachier
 
-    valid_params = (
-        p
-        for p in params.items()
-        if hasattr(cachier.config._default_params, p[0])
+    valid_params = {
+        k: v
+        for k, v in params.items()
+        if hasattr(cachier.config._default_params, k)
+    }
+    cachier.config._default_params = replace(
+        cachier.config._default_params, **valid_params
     )
-    replace(_default_params, **valid_params)
 
 
-def get_default_params():
+def get_default_params() -> Params:
     """Get current set of default parameters."""
     import cachier
 

--- a/src/cachier/config.py
+++ b/src/cachier/config.py
@@ -54,13 +54,14 @@ def _update_with_defaults(
 
 def set_default_params(**params: Mapping) -> None:
     """Configure default parameters applicable to all memoized functions."""
-    # This function is kept for backwards compatibility with desperation warning
+    # It is kept for backwards compatibility with desperation warning
     import warnings
 
     warnings.warn(
-        "Called `set_default_params` is deprecated and will be removed in a future version. "
-        "Please use `set_global_params` instead.",
+        "Called `set_default_params` is deprecated and will be removed."
+        " Please use `set_global_params` instead.",
         DeprecationWarning,
+        stacklevel=2,
     )
     set_global_params(**params)
 
@@ -92,13 +93,14 @@ def set_global_params(**params: Mapping) -> None:
 
 def get_default_params() -> Params:
     """Get current set of default parameters."""
-    # This function is kept for backwards compatibility with desperation warning
+    # It is kept for backwards compatibility with desperation warning
     import warnings
 
     warnings.warn(
-        "Called `get_default_params` is deprecated and will be removed in a future version. "
-        "Please use `get_global_params` instead.",
+        "Called `get_default_params` is deprecated and will be removed."
+        " Please use `get_global_params` instead.",
         DeprecationWarning,
+        stacklevel=2,
     )
     return get_global_params()
 

--- a/src/cachier/config.py
+++ b/src/cachier/config.py
@@ -6,8 +6,6 @@ from collections.abc import Mapping
 from dataclasses import dataclass, replace
 from typing import Optional, Union
 
-from docutils.nodes import warning
-
 from ._types import Backend, HashFunc, Mongetter
 
 

--- a/src/cachier/config.py
+++ b/src/cachier/config.py
@@ -52,7 +52,7 @@ def _update_with_defaults(
     return param
 
 
-def set_default_params(**params: Mapping) -> None:
+def set_global_params(**params: Mapping) -> None:
     """Configure global parameters applicable to all memoized functions.
 
     This function takes the same keyword parameters as the ones defined in the
@@ -77,7 +77,7 @@ def set_default_params(**params: Mapping) -> None:
     )
 
 
-def get_default_params() -> Params:
+def get_global_params() -> Params:
     """Get current set of default parameters."""
     import cachier
 

--- a/src/cachier/config.py
+++ b/src/cachier/config.py
@@ -79,7 +79,9 @@ def set_default_params(**params):
     import cachier
 
     valid_params = (
-        p for p in params.items() if hasattr(cachier.config._default_params, p[0])
+        p
+        for p in params.items()
+        if hasattr(cachier.config._default_params, p[0])
     )
     replace(_default_params, **valid_params)
 

--- a/src/cachier/config.py
+++ b/src/cachier/config.py
@@ -6,6 +6,8 @@ from collections.abc import Mapping
 from dataclasses import dataclass, replace
 from typing import Optional, Union
 
+from docutils.nodes import warning
+
 from ._types import Backend, HashFunc, Mongetter
 
 
@@ -52,6 +54,19 @@ def _update_with_defaults(
     return param
 
 
+def set_default_params(**params: Mapping) -> None:
+    """Configure default parameters applicable to all memoized functions."""
+    # This function is kept for backwards compatibility with desperation warning
+    import warnings
+
+    warnings.warn(
+        "Called `set_default_params` is deprecated and will be removed in a future version. "
+        "Please use `set_global_params` instead.",
+        DeprecationWarning,
+    )
+    set_global_params(**params)
+
+
 def set_global_params(**params: Mapping) -> None:
     """Configure global parameters applicable to all memoized functions.
 
@@ -75,6 +90,19 @@ def set_global_params(**params: Mapping) -> None:
     cachier.config._global_params = replace(
         cachier.config._global_params, **valid_params
     )
+
+
+def get_default_params() -> Params:
+    """Get current set of default parameters."""
+    # This function is kept for backwards compatibility with desperation warning
+    import warnings
+
+    warnings.warn(
+        "Called `get_default_params` is deprecated and will be removed in a future version. "
+        "Please use `get_global_params` instead.",
+        DeprecationWarning,
+    )
+    return get_global_params()
 
 
 def get_global_params() -> Params:

--- a/src/cachier/core.py
+++ b/src/cachier/core.py
@@ -21,7 +21,6 @@ from .config import (
     Backend,
     HashFunc,
     Mongetter,
-    _default_params,
     _update_with_defaults,
 )
 from .cores.base import RecalculationNeeded, _BaseCore
@@ -176,6 +175,8 @@ def cachier(
         None will not be cached and are recalculated every call.
 
     """
+    from .config import _global_params
+
     # Check for deprecated parameters
     if hash_params is not None:
         message = (
@@ -244,7 +245,7 @@ def cachier(
             _print = lambda x: None  # noqa: E731
             if verbose:
                 _print = print
-            if ignore_cache or not _default_params.caching_enabled:
+            if ignore_cache or not _global_params.caching_enabled:
                 return (
                     func(args[0], **kwargs)
                     if core.func_is_method

--- a/src/cachier/core.py
+++ b/src/cachier/core.py
@@ -244,7 +244,7 @@ def cachier(
             _print = lambda x: None  # noqa: E731
             if verbose:
                 _print = print
-            if ignore_cache or not _default_params["caching_enabled"]:
+            if ignore_cache or not _default_params.caching_enabled:
                 return (
                     func(args[0], **kwargs)
                     if core.func_is_method

--- a/tests/test_core_lookup.py
+++ b/tests/test_core_lookup.py
@@ -2,12 +2,12 @@
 
 import pytest
 
-from cachier import cachier, get_default_params
+from cachier import cachier, get_global_params
 from cachier.cores.mongo import MissingMongetter
 
 
 def test_get_default_params():
-    params = get_default_params()
+    params = get_global_params()
     assert sorted(vars(params).keys()) == [
         "allow_none",
         "backend",

--- a/tests/test_core_lookup.py
+++ b/tests/test_core_lookup.py
@@ -8,7 +8,7 @@ from cachier.cores.mongo import MissingMongetter
 
 def test_get_default_params():
     params = get_default_params()
-    assert tuple(sorted(params)) == (
+    assert sorted(vars(params).keys()) == [
         "allow_none",
         "backend",
         "cache_dir",
@@ -20,7 +20,7 @@ def test_get_default_params():
         "separate_files",
         "stale_after",
         "wait_for_calc_timeout",
-    )
+    ]
 
 
 def test_bad_name(name="nope"):

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -12,15 +12,15 @@ import cachier
 from tests.test_mongo_core import _test_mongetter
 
 MONGO_DELTA = datetime.timedelta(seconds=3)
-_fresh_defaults = replace(cachier.get_default_params())
+_copied_defaults = replace(cachier.get_global_params())
 
 
 def setup_function():
-    cachier.set_default_params(**vars(_fresh_defaults))
+    cachier.set_global_params(**vars(_copied_defaults))
 
 
 def teardown_function():
-    cachier.set_default_params(**vars(_fresh_defaults))
+    cachier.set_global_params(**vars(_copied_defaults))
 
 
 def test_hash_func_default_param():
@@ -31,7 +31,7 @@ def test_hash_func_default_param():
     def fast_hash_func(args, kwds):
         return "hash"
 
-    cachier.set_default_params(hash_func=slow_hash_func)
+    cachier.set_global_params(hash_func=slow_hash_func)
 
     @cachier.cachier()
     def global_test_1():
@@ -52,7 +52,7 @@ def test_hash_func_default_param():
 
 
 def test_backend_default_param():
-    cachier.set_default_params(backend="memory")
+    cachier.set_global_params(backend="memory")
 
     @cachier.cachier()
     def global_test_1():
@@ -68,7 +68,7 @@ def test_backend_default_param():
 
 @pytest.mark.mongo
 def test_mongetter_default_param():
-    cachier.set_default_params(mongetter=_test_mongetter)
+    cachier.set_global_params(mongetter=_test_mongetter)
 
     @cachier.cachier()
     def global_test_1():
@@ -83,7 +83,7 @@ def test_mongetter_default_param():
 
 
 def test_cache_dir_default_param(tmpdir):
-    cachier.set_default_params(cache_dir=tmpdir / "1")
+    cachier.set_global_params(cache_dir=tmpdir / "1")
 
     @cachier.cachier()
     def global_test_1():
@@ -98,7 +98,7 @@ def test_cache_dir_default_param(tmpdir):
 
 
 def test_separate_files_default_param(tmpdir):
-    cachier.set_default_params(separate_files=True)
+    cachier.set_global_params(separate_files=True)
 
     @cachier.cachier(cache_dir=tmpdir / "1")
     def global_test_1(arg_1, arg_2):
@@ -118,7 +118,7 @@ def test_separate_files_default_param(tmpdir):
 
 
 def test_allow_none_default_param(tmpdir):
-    cachier.set_default_params(
+    cachier.set_global_params(
         allow_none=True,
         separate_files=True,
         verbose_cache=True,
@@ -168,7 +168,7 @@ def test_stale_after_applies_dynamically(backend, mongetter):
         """Some function."""
         return random.random() + arg_1 + arg_2
 
-    cachier.set_default_params(stale_after=MONGO_DELTA)
+    cachier.set_global_params(stale_after=MONGO_DELTA)
 
     _stale_after_test.clear_cache()
     val1 = _stale_after_test(1, 2)
@@ -188,7 +188,7 @@ def test_next_time_applies_dynamically(backend, mongetter):
         """Some function."""
         return random.random()
 
-    cachier.set_default_params(stale_after=NEXT_AFTER_DELTA, next_time=True)
+    cachier.set_global_params(stale_after=NEXT_AFTER_DELTA, next_time=True)
 
     _stale_after_next_time.clear_cache()
     val1 = _stale_after_next_time(1, 2)
@@ -218,7 +218,7 @@ def test_wait_for_calc_applies_dynamically(backend, mongetter):
         res = _wait_for_calc_timeout_slow(1, 2)
         res_queue.put(res)
 
-    cachier.set_default_params(wait_for_calc_timeout=2)
+    cachier.set_global_params(wait_for_calc_timeout=2)
     _wait_for_calc_timeout_slow.clear_cache()
     res_queue = queue.Queue()
     thread1 = threading.Thread(

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -12,15 +12,15 @@ import cachier
 from tests.test_mongo_core import _test_mongetter
 
 MONGO_DELTA = datetime.timedelta(seconds=3)
-_default_params = replace(cachier.get_default_params())
+_fresh_defaults = replace(cachier.get_default_params())
 
 
 def setup_function():
-    cachier.set_default_params(**_default_params)
+    cachier.set_default_params(**vars(_fresh_defaults))
 
 
 def teardown_function():
-    cachier.set_default_params(**_default_params)
+    cachier.set_default_params(**vars(_fresh_defaults))
 
 
 def test_hash_func_default_param():

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -4,6 +4,7 @@ import queue
 import random
 import threading
 import time
+from dataclasses import replace
 
 import pytest
 
@@ -11,7 +12,7 @@ import cachier
 from tests.test_mongo_core import _test_mongetter
 
 MONGO_DELTA = datetime.timedelta(seconds=3)
-_default_params = cachier.get_default_params().copy()
+_default_params = replace(cachier.get_default_params())
 
 
 def setup_function():

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -229,15 +229,17 @@ def test_separate_processes():
 
 def test_global_disable():
     @cachier.cachier()
-    def get_random():
+    def get_random() -> float:
         return random()
 
     get_random.clear_cache()
     result_1 = get_random()
     result_2 = get_random()
     cachier.disable_caching()
+    assert cachier.config._default_params.caching_enabled is False
     result_3 = get_random()
     cachier.enable_caching()
+    assert cachier.config._default_params.caching_enabled is True
     result_4 = get_random()
     assert result_1 == result_2 == result_4
     assert result_1 != result_3

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -236,10 +236,10 @@ def test_global_disable():
     result_1 = get_random()
     result_2 = get_random()
     cachier.disable_caching()
-    assert cachier.config._default_params.caching_enabled is False
+    assert cachier.config._global_params.caching_enabled is False
     result_3 = get_random()
     cachier.enable_caching()
-    assert cachier.config._default_params.caching_enabled is True
+    assert cachier.config._global_params.caching_enabled is True
     result_4 = get_random()
     assert result_1 == result_2 == result_4
     assert result_1 != result_3

--- a/tests/test_pickle_core.py
+++ b/tests/test_pickle_core.py
@@ -329,7 +329,7 @@ _BAD_CACHE_FNAME_SEPARATE_FILES = (
     ".tests.test_pickle_core._bad_cache_"
     f"{hashlib.sha256(pickle.dumps((0.13, 0.02))).hexdigest()}"
 )
-EXPANDED_CACHIER_DIR = os.path.expanduser(_default_params["cache_dir"])
+EXPANDED_CACHIER_DIR = os.path.expanduser(_default_params.cache_dir)
 _BAD_CACHE_FPATH = os.path.join(EXPANDED_CACHIER_DIR, _BAD_CACHE_FNAME)
 _BAD_CACHE_FPATH_SEPARATE_FILES = os.path.join(
     EXPANDED_CACHIER_DIR, _BAD_CACHE_FNAME_SEPARATE_FILES

--- a/tests/test_pickle_core.py
+++ b/tests/test_pickle_core.py
@@ -30,7 +30,7 @@ import hashlib
 import pandas as pd
 
 from cachier import cachier
-from cachier.core import _default_params
+from cachier.config import _global_params
 
 
 def _get_decorated_func(func, **kwargs):
@@ -329,7 +329,7 @@ _BAD_CACHE_FNAME_SEPARATE_FILES = (
     ".tests.test_pickle_core._bad_cache_"
     f"{hashlib.sha256(pickle.dumps((0.13, 0.02))).hexdigest()}"
 )
-EXPANDED_CACHIER_DIR = os.path.expanduser(_default_params.cache_dir)
+EXPANDED_CACHIER_DIR = os.path.expanduser(_global_params.cache_dir)
 _BAD_CACHE_FPATH = os.path.join(EXPANDED_CACHIER_DIR, _BAD_CACHE_FNAME)
 _BAD_CACHE_FPATH_SEPARATE_FILES = os.path.join(
     EXPANDED_CACHIER_DIR, _BAD_CACHE_FNAME_SEPARATE_FILES


### PR DESCRIPTION
improve readability and reduce eventual typo errors while manipulating keys

with IDE it is now feasible to track usage
also suggesting to rename `default_params` to `global_params` as it is better fit