### PR TITLE
fix: crash with `None` & confusing tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,6 +148,7 @@ addopts = [
   "-r a",
   "-v",
   "-s",
+  "-W error"
 ]
 markers = [
   "mongo: test the MongoDB core",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,7 +148,7 @@ addopts = [
   "-r a",
   "-v",
   "-s",
-  "-W error"
+  "-W error",
 ]
 markers = [
   "mongo: test the MongoDB core",

--- a/src/cachier/cores/pickle.py
+++ b/src/cachier/cores/pickle.py
@@ -54,7 +54,7 @@ class _PickleCore(_BaseCore):
                     self.observer.stop()
                 # else:
                 #     print('NOT stopping observer... :(')
-            except TypeError:
+            except AttributeError:  # catching entry being None
                 self.value = None
                 self.observer.stop()
 

--- a/src/cachier/cores/pickle.py
+++ b/src/cachier/cores/pickle.py
@@ -48,7 +48,7 @@ class _PickleCore(_BaseCore):
         def _check_calculation(self) -> None:
             entry = self.core.get_entry_by_key(self.key, True)[1]
             try:
-                if not entry._processing:
+                if entry and not entry._processing:
                     # print('stopping observer!')
                     self.value = entry.value
                     self.observer.stop()

--- a/src/cachier/cores/pickle.py
+++ b/src/cachier/cores/pickle.py
@@ -48,7 +48,7 @@ class _PickleCore(_BaseCore):
         def _check_calculation(self) -> None:
             entry = self.core.get_entry_by_key(self.key, True)[1]
             try:
-                if entry and not entry._processing:
+                if not entry._processing:
                     # print('stopping observer!')
                     self.value = entry.value
                     self.observer.stop()

--- a/tests/test_pickle_core.py
+++ b/tests/test_pickle_core.py
@@ -395,16 +395,17 @@ def _helper_bad_cache_file(sleeptime, separate_files):
 
 # we want this to succeed at least once
 @pytest.mark.pickle
-@pytest.mark.xfail
 @pytest.mark.parametrize("separate_files", [True, False])
 def test_bad_cache_file(separate_files):
     """Test pickle core handling of bad cache files."""
     sleeptimes = [0.1, 0.2, 0.3, 0.5, 0.6, 0.7, 0.8, 1, 1.5, 2]
     sleeptimes = sleeptimes + sleeptimes
+    bad_file = False
     for sleeptime in sleeptimes:
         if _helper_bad_cache_file(sleeptime, separate_files):
-            return
-    raise AssertionError()
+            bad_file = True
+            break
+    assert not bad_file
 
 
 def _delete_cache(arg_1, arg_2):
@@ -486,16 +487,17 @@ def _helper_delete_cache_file(sleeptime, separate_files):
 
 
 @pytest.mark.pickle
-@pytest.mark.xfail
 @pytest.mark.parametrize("separate_files", [False, True])
 def test_delete_cache_file(separate_files):
     """Test pickle core handling of missing cache files."""
     sleeptimes = [0.1, 0.2, 0.3, 0.5, 0.7, 1]
     sleeptimes = sleeptimes * 4
+    deleted = False
     for sleeptime in sleeptimes:
         if _helper_delete_cache_file(sleeptime, separate_files):
-            return
-    raise AssertionError()
+            deleted = True
+            break
+    assert not deleted
 
 
 @pytest.mark.pickle

--- a/tests/test_pickle_core.py
+++ b/tests/test_pickle_core.py
@@ -398,10 +398,10 @@ def _helper_bad_cache_file(sleep_time: float, separate_files: bool):
 @pytest.mark.parametrize("separate_files", [True, False])
 def test_bad_cache_file(separate_files):
     """Test pickle core handling of bad cache files."""
-    sleeptimes = [0.1, 0.2, 0.3, 0.5, 0.6, 0.7, 0.8, 1, 1.5, 2]
+    sleep_times = [0.1, 0.2, 0.3, 0.5, 0.6, 0.7, 0.8, 1, 1.5, 2]
     bad_file = False
-    for sleeptime in sleeptimes * 2:
-        if _helper_bad_cache_file(sleeptime, separate_files):
+    for sleep_time in sleep_times * 2:
+        if _helper_bad_cache_file(sleep_time, separate_files):
             bad_file = True
             break
     # it is expected that for separate_files=True files will not be bad
@@ -492,8 +492,8 @@ def test_delete_cache_file(separate_files):
     """Test pickle core handling of missing cache files."""
     sleep_times = [0.1, 0.2, 0.3, 0.5, 0.7, 1]
     deleted = False
-    for sleeptime in sleep_times * 4:
-        if _helper_delete_cache_file(sleeptime, separate_files):
+    for sleep_time in sleep_times * 4:
+        if _helper_delete_cache_file(sleep_time, separate_files):
             deleted = True
             break
     # it is expected that for separate_files=True files will not be deleted

--- a/tests/test_pickle_core.py
+++ b/tests/test_pickle_core.py
@@ -430,7 +430,9 @@ _DEL_CACHE_FPATHS = {
 }
 
 
-def _calls_delete_cache(del_cache_func, res_queue, del_cache: bool, separate_files: bool):
+def _calls_delete_cache(
+    del_cache_func, res_queue, del_cache: bool, separate_files: bool
+):
     try:
         # print('in')
         res = del_cache_func(0.13, 0.02)

--- a/tests/test_pickle_core.py
+++ b/tests/test_pickle_core.py
@@ -352,7 +352,7 @@ def _calls_bad_cache(bad_cache_func, res_queue, trash_cache, separate_files):
         res_queue.put(exc)
 
 
-def _helper_bad_cache_file(sleeptime, separate_files):
+def _helper_bad_cache_file(sleep_time: float, separate_files: bool):
     """Test pickle core handling of bad cache files."""
     _bad_cache_decorated = _get_decorated_func(
         _bad_cache, separate_files=separate_files
@@ -380,7 +380,7 @@ def _helper_bad_cache_file(sleeptime, separate_files):
         daemon=True,
     )
     thread1.start()
-    sleep(sleeptime)
+    sleep(sleep_time)
     thread2.start()
     thread1.join(timeout=2)
     thread2.join(timeout=2)
@@ -399,13 +399,13 @@ def _helper_bad_cache_file(sleeptime, separate_files):
 def test_bad_cache_file(separate_files):
     """Test pickle core handling of bad cache files."""
     sleeptimes = [0.1, 0.2, 0.3, 0.5, 0.6, 0.7, 0.8, 1, 1.5, 2]
-    sleeptimes = sleeptimes + sleeptimes
     bad_file = False
-    for sleeptime in sleeptimes:
+    for sleeptime in sleeptimes * 2:
         if _helper_bad_cache_file(sleeptime, separate_files):
             bad_file = True
             break
-    assert not bad_file
+    # it is expected that for separate_files=True files will not be bad
+    assert bad_file is not separate_files
 
 
 def _delete_cache(arg_1, arg_2):
@@ -430,7 +430,7 @@ _DEL_CACHE_FPATHS = {
 }
 
 
-def _calls_delete_cache(del_cache_func, res_queue, del_cache, separate_files):
+def _calls_delete_cache(del_cache_func, res_queue, del_cache: bool, separate_files: bool):
     try:
         # print('in')
         res = del_cache_func(0.13, 0.02)
@@ -444,7 +444,7 @@ def _calls_delete_cache(del_cache_func, res_queue, del_cache, separate_files):
         res_queue.put(exc)
 
 
-def _helper_delete_cache_file(sleeptime, separate_files):
+def _helper_delete_cache_file(sleep_time: float, separate_files: bool):
     """Test pickle core handling of missing cache files."""
     _delete_cache_decorated = _get_decorated_func(
         _delete_cache, separate_files=separate_files
@@ -472,7 +472,7 @@ def _helper_delete_cache_file(sleeptime, separate_files):
         daemon=True,
     )
     thread1.start()
-    sleep(sleeptime)
+    sleep(sleep_time)
     thread2.start()
     thread1.join(timeout=2)
     thread2.join(timeout=2)
@@ -490,14 +490,14 @@ def _helper_delete_cache_file(sleeptime, separate_files):
 @pytest.mark.parametrize("separate_files", [False, True])
 def test_delete_cache_file(separate_files):
     """Test pickle core handling of missing cache files."""
-    sleeptimes = [0.1, 0.2, 0.3, 0.5, 0.7, 1]
-    sleeptimes = sleeptimes * 4
+    sleep_times = [0.1, 0.2, 0.3, 0.5, 0.7, 1]
     deleted = False
-    for sleeptime in sleeptimes:
+    for sleeptime in sleep_times * 4:
         if _helper_delete_cache_file(sleeptime, separate_files):
             deleted = True
             break
-    assert not deleted
+    # it is expected that for separate_files=True files will not be deleted
+    assert deleted is not separate_files
 
 
 @pytest.mark.pickle


### PR DESCRIPTION
closes #247 

cleaning confusing testing which hided some issues
```
XFAIL tests/test_pickle_core.py::test_bad_cache_file[True]
XFAIL tests/test_pickle_core.py::test_delete_cache_file[True]
XPASS tests/test_pickle_core.py::test_bad_cache_file[False]
XPASS tests/test_pickle_core.py::test_delete_cache_file[False]
```

cc: @shaypal5