### PR TITLE
Disable dyanmic_context for codecov

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,7 +158,7 @@ markers = [
 
 [tool.coverage.run]
 branch = true
-dynamic_context = "test_function"
+# dynamic_context = "test_function"
 omit = [
   "tests/*",
   "cachier/_version.py",


### PR DESCRIPTION
Let's see if this solves the codecov errors bugging all the tests.

The PR solving [this issue](https://github.com/pytest-dev/pytest-cov/issues/604) of pytest-cov was released 3 days ago (October 30th, 2024), and this new version is what causuing the error. So either this or tying `pytest-cov` to `v5.0.0`.