### PR TITLE
Fix type annotations for `set_global_params` and `set_default_params`

### DIFF
--- a/src/cachier/config.py
+++ b/src/cachier/config.py
@@ -2,7 +2,6 @@ import hashlib
 import os
 import pickle
 import threading
-from collections.abc import Mapping
 from dataclasses import dataclass, replace
 from datetime import datetime, timedelta
 from typing import Any, Optional, Union
@@ -65,7 +64,7 @@ def _update_with_defaults(
     return param
 
 
-def set_default_params(**params: Mapping) -> None:
+def set_default_params(**params: Any) -> None:
     """Configure default parameters applicable to all memoized functions."""
     # It is kept for backwards compatibility with desperation warning
     import warnings
@@ -79,7 +78,7 @@ def set_default_params(**params: Mapping) -> None:
     set_global_params(**params)
 
 
-def set_global_params(**params: Mapping) -> None:
+def set_global_params(**params: Any) -> None:
     """Configure global parameters applicable to all memoized functions.
 
     This function takes the same keyword parameters as the ones defined in the


### PR DESCRIPTION
Hello, thanks for maintenance. 

I fixed the wrong type annotations on `set_global_params` and `set_default_params`.

As we can see [Arbitrary argument lists and default argument values](https://peps.python.org/pep-0484/#arbitrary-argument-lists-and-default-argument-values), `**kwargs: T` types `kwargs` to `dict[str, T]`, not `T`. 

Thus on the code bellow:
```python
def set_default_params(**params: Mapping) -> None:
```
type of `params` is `dict[str, Mapping]`, but it should be probably `dict[str, Any]`. 