### PR TITLE
Implement automatic cleanup of stale cache entries

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -146,6 +146,8 @@ These parameters can be changed at any time and they will apply to all decorator
 *  `stale_after`
 *  `next_time`
 *  `wait_for_calc_timeout`
+*  `cleanup_stale`
+*  `cleanup_interval`
 
 The current defaults can be fetched by calling `get_default_params`.
 
@@ -191,6 +193,17 @@ Sometimes you may want your function to trigger a calculation when it encounters
   @cachier(next_time=True)
 
 Further function calls made while the calculation is being performed will not trigger redundant calculations.
+
+Automatic Cleanup of Stale Values
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Setting ``cleanup_stale=True`` on a decorator will spawn a background thread that periodically removes stale cache entries. The interval between cleanup runs is controlled by ``cleanup_interval`` and defaults to one day.
+
+.. code-block:: python
+
+  @cachier(stale_after=timedelta(seconds=30), cleanup_stale=True)
+  def compute():
+      ...
+
 
 
 Working with unhashable arguments

--- a/src/cachier/config.py
+++ b/src/cachier/config.py
@@ -63,6 +63,8 @@ class Params:
     separate_files: bool = False
     wait_for_calc_timeout: int = 0
     allow_none: bool = False
+    cleanup_stale: bool = False
+    cleanup_interval: timedelta = timedelta(days=1)
 
 
 _global_params = Params()

--- a/src/cachier/config.py
+++ b/src/cachier/config.py
@@ -132,7 +132,7 @@ def set_global_params(**params: Any) -> None:
     }
     cachier.config._global_params = replace(
         cachier.config._global_params,
-        **valid_params,  # type: ignore[arg-type]
+        **valid_params,
     )
 
 

--- a/src/cachier/cores/base.py
+++ b/src/cachier/cores/base.py
@@ -10,6 +10,7 @@
 import abc  # for the _BaseCore abstract base class
 import inspect
 import threading
+from datetime import timedelta
 from typing import Callable, Optional, Tuple
 
 from .._types import HashFunc
@@ -112,3 +113,7 @@ class _BaseCore:
     @abc.abstractmethod
     def clear_being_calculated(self) -> None:
         """Mark all entries in this cache as not being calculated."""
+
+    @abc.abstractmethod
+    def delete_stale_entries(self, stale_after: timedelta) -> None:
+        """Delete cache entries older than ``stale_after``."""

--- a/src/cachier/cores/memory.py
+++ b/src/cachier/cores/memory.py
@@ -1,7 +1,7 @@
 """A memory-based caching core for cachier."""
 
 import threading
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any, Dict, Optional, Tuple
 
 from .._types import HashFunc
@@ -103,3 +103,13 @@ class _MemoryCore(_BaseCore):
             for entry in self.cache.values():
                 entry._processing = False
                 entry._condition = None
+
+    def delete_stale_entries(self, stale_after: timedelta) -> None:
+        """Remove stale entries from the in-memory cache."""
+        now = datetime.now()
+        with self.lock:
+            keys_to_delete = [
+                k for k, v in self.cache.items() if now - v.time > stale_after
+            ]
+            for key in keys_to_delete:
+                del self.cache[key]

--- a/src/cachier/cores/mongo.py
+++ b/src/cachier/cores/mongo.py
@@ -12,7 +12,7 @@ import sys  # to make sure that pymongo was imported
 import time  # to sleep when waiting on Mongo cache\
 import warnings  # to warn if pymongo is missing
 from contextlib import suppress
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any, Optional, Tuple
 
 from .._types import HashFunc, Mongetter
@@ -145,4 +145,11 @@ class _MongoCore(_BaseCore):
                 "processing": True,
             },
             update={"$set": {"processing": False}},
+        )
+
+    def delete_stale_entries(self, stale_after: timedelta) -> None:
+        """Delete stale entries from the MongoDB cache."""
+        threshold = datetime.now() - stale_after
+        self.mongo_collection.delete_many(
+            filter={"func": self._func_str, "time": {"$lt": threshold}}
         )

--- a/src/cachier/cores/pickle.py
+++ b/src/cachier/cores/pickle.py
@@ -118,8 +118,8 @@ class _PickleCore(_BaseCore):
 
     def _load_cache_dict(self) -> Dict[str, CacheEntry]:
         try:
-            with portalocker.Lock(self.cache_fpath, mode="rb") as cf:  # type: ignore[arg-type]
-                cache = pickle.load(cf)  # type: ignore[arg-type]
+            with portalocker.Lock(self.cache_fpath, mode="rb") as cf:
+                cache = pickle.load(cf)
             self._cache_used_fpath = str(self.cache_fpath)
         except (FileNotFoundError, EOFError):
             cache = {}
@@ -145,8 +145,8 @@ class _PickleCore(_BaseCore):
         fpath = self.cache_fpath
         fpath += f"_{hash_str or key}"
         try:
-            with portalocker.Lock(fpath, mode="rb") as cache_file:  # type: ignore[arg-type]
-                entry = pickle.load(cache_file)  # type: ignore[arg-type]
+            with portalocker.Lock(fpath, mode="rb") as cache_file:
+                entry = pickle.load(cache_file)
             return _PickleCore._convert_legacy_cache_entry(entry)
         except (FileNotFoundError, EOFError):
             return None
@@ -184,8 +184,8 @@ class _PickleCore(_BaseCore):
         elif hash_str is not None:
             fpath += f"_{hash_str}"
         with self.lock:
-            with portalocker.Lock(fpath, mode="wb") as cf:  # type: ignore[arg-type]
-                pickle.dump(cache, cf, protocol=4)  # type: ignore[arg-type]
+            with portalocker.Lock(fpath, mode="wb") as cf:
+                pickle.dump(cache, cf, protocol=4)
             # the same as check for separate_file, but changed for typing
             if isinstance(cache, dict):
                 self._cache_dict = cache

--- a/src/cachier/cores/pickle.py
+++ b/src/cachier/cores/pickle.py
@@ -10,6 +10,7 @@ import logging
 import os
 import pickle  # for local caching
 import time
+from contextlib import suppress
 from datetime import datetime, timedelta
 from typing import Any, Dict, Optional, Tuple, Union
 
@@ -377,7 +378,8 @@ class _PickleCore(_BaseCore):
                     hash_str=subpath.split("_")[-1]
                 )
                 if entry is not None and (now - entry.time > stale_after):
-                    os.remove(os.path.join(path, subpath))
+                    with suppress(FileNotFoundError):
+                        os.remove(os.path.join(path, subpath))
             return
 
         with self.lock:

--- a/src/cachier/cores/sql.py
+++ b/src/cachier/cores/sql.py
@@ -109,10 +109,10 @@ class _SQLCore(_BaseCore):
             value = pickle.loads(row.value) if row.value is not None else None
             entry = CacheEntry(
                 value=value,
-                time=row.timestamp,  # type: ignore[arg-type]
-                stale=row.stale,  # type: ignore[arg-type]
-                _processing=row.processing,  # type: ignore[arg-type]
-                _completed=row.completed,  # type: ignore[arg-type]
+                time=row.timestamp,
+                stale=row.stale,
+                _processing=row.processing,
+                _completed=row.completed,
             )
             return key, entry
 

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -1,16 +1,28 @@
 import os
 import pickle
 import time
+from dataclasses import replace
 from datetime import timedelta
 
 import pytest
 
-from cachier import cachier
+import cachier
+from cachier import cachier as cachier_dec
+
+_copied_defaults = replace(cachier.get_global_params())
+
+
+def setup_function() -> None:
+    cachier.set_global_params(**vars(_copied_defaults))
+
+
+def teardown_function() -> None:
+    cachier.set_global_params(**vars(_copied_defaults))
 
 
 @pytest.mark.pickle
 def test_cleanup_stale_entries(tmp_path):
-    @cachier(
+    @cachier_dec(
         cache_dir=tmp_path,
         stale_after=timedelta(seconds=1),
         cleanup_stale=True,

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -1,0 +1,37 @@
+import os
+import pickle
+import time
+from datetime import timedelta
+
+import pytest
+
+from cachier import cachier
+
+
+@pytest.mark.pickle
+def test_cleanup_stale_entries(tmp_path):
+    @cachier(
+        cache_dir=tmp_path,
+        stale_after=timedelta(seconds=1),
+        cleanup_stale=True,
+        cleanup_interval=timedelta(seconds=0),
+    )
+    def add(x):
+        return x + 1
+
+    add.clear_cache()
+    add(1)
+    add(2)
+    fname = f".{add.__module__}.{add.__qualname__}".replace("<", "_").replace(
+        ">", "_"
+    )
+    cache_path = os.path.join(add.cache_dpath(), fname)
+    with open(cache_path, "rb") as fh:
+        data = pickle.load(fh)
+    assert len(data) == 2
+    time.sleep(1.1)
+    add(1)
+    time.sleep(0.2)
+    with open(cache_path, "rb") as fh:
+        data = pickle.load(fh)
+    assert len(data) == 1

--- a/tests/test_core_lookup.py
+++ b/tests/test_core_lookup.py
@@ -12,6 +12,8 @@ def test_get_default_params():
         "backend",
         "cache_dir",
         "caching_enabled",
+        "cleanup_interval",
+        "cleanup_stale",
         "hash_func",
         "mongetter",
         "next_time",


### PR DESCRIPTION
## Summary
- Addresses issue #26
- add `cleanup_stale` and `cleanup_interval` parameters
- implement stale-entry deletion in each backend
- periodically run cleanup in `cachier` decorator
- document new feature and defaults
- add tests for pickle backend cleanup

## Testing
- `ruff check .`
- `mypy --install-types --non-interactive src/cachier`
- `pytest tests/test_cleanup.py -q -m pickle`

------
https://chatgpt.com/codex/tasks/task_e_68761d7d53e48323ba091be1ae2af698