### PR TITLE
Dev/pr 297: Add return_stale_on_timeout parameter for stale-while-revalidate caching

### DIFF
--- a/demo_return_stale_on_timeout.py
+++ b/demo_return_stale_on_timeout.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Demonstration of the new return_stale_on_timeout feature."""
+
+import time
+import threading
+from datetime import timedelta
+
+import cachier
+
+
+def demo_return_stale_on_timeout():
+    """Demonstrate the return_stale_on_timeout feature."""
+    
+    print("🎯 Cachier return_stale_on_timeout Feature Demo")
+    print("=" * 50)
+    
+    @cachier.cachier(
+        backend="memory",
+        stale_after=timedelta(seconds=2),     # Fresh for 2 seconds
+        wait_for_calc_timeout=3,              # Wait up to 3 seconds for calculation
+        return_stale_on_timeout=True,         # Return stale value if timeout
+        next_time=False,                      # Don't return stale immediately
+    )
+    def expensive_api_call(query):
+        """Simulate an expensive API call that takes 5 seconds."""
+        print(f"  🔄 Making expensive API call for '{query}'...")
+        time.sleep(5)  # Simulates network request
+        return f"Result for {query}: {len(query)} chars"
+    
+    expensive_api_call.clear_cache()
+    
+    # 1. First call - will cache the result
+    print("\n1️⃣ First call (cold cache):")
+    result1 = expensive_api_call("hello world")
+    print(f"   ✅ Got: {result1}")
+    
+    # 2. Second call while fresh - returns cached result immediately  
+    print("\n2️⃣ Second call (fresh cache):")
+    start_time = time.time()
+    result2 = expensive_api_call("hello world")
+    elapsed = time.time() - start_time
+    print(f"   ✅ Got: {result2} (took {elapsed:.2f}s)")
+    
+    # 3. Wait for cache to become stale
+    print("\n⏰ Waiting for cache to become stale (2+ seconds)...")
+    time.sleep(2.5)
+    
+    # 4. Start a background calculation
+    print("\n3️⃣ Starting background calculation...")
+    def background_refresh():
+        expensive_api_call("hello world")
+    
+    thread = threading.Thread(target=background_refresh)
+    thread.start()
+    time.sleep(0.5)  # Let background thread start
+    
+    # 5. This call will wait up to 3 seconds, then return stale value
+    print("\n4️⃣ Main call (should return stale value after 3s timeout):")
+    start_time = time.time()
+    result3 = expensive_api_call("hello world") 
+    elapsed = time.time() - start_time
+    print(f"   ✅ Got: {result3} (took {elapsed:.2f}s)")
+    
+    if elapsed < 4:
+        print("   🎉 SUCCESS! Returned stale value instead of waiting 5 seconds!")
+    else:
+        print("   ❌ Something went wrong - took too long")
+    
+    # Wait for background thread to complete
+    thread.join()
+    
+    print("\n📋 Summary:")
+    print("   • Fresh values returned immediately")  
+    print("   • Stale values trigger background refresh")
+    print("   • If refresh takes too long, return stale value")
+    print("   • This keeps your application responsive!")
+
+
+def demo_comparison():
+    """Compare with and without return_stale_on_timeout."""
+    
+    print("\n\n🔄 Comparison Demo")
+    print("=" * 50)
+    
+    # Without return_stale_on_timeout (default behavior)
+    @cachier.cachier(
+        backend="memory",
+        stale_after=timedelta(seconds=1),
+        wait_for_calc_timeout=2,
+        return_stale_on_timeout=False,  # Default
+    )
+    def slow_func_old(x):
+        time.sleep(3)
+        return x * 2
+    
+    # With return_stale_on_timeout
+    @cachier.cachier(
+        backend="memory", 
+        stale_after=timedelta(seconds=1),
+        wait_for_calc_timeout=2,
+        return_stale_on_timeout=True,   # New feature
+    )
+    def slow_func_new(x):
+        time.sleep(3)
+        return x * 2
+    
+    slow_func_old.clear_cache()
+    slow_func_new.clear_cache()
+    
+    # Cache initial values
+    print("Caching initial values...")
+    slow_func_old(10)
+    slow_func_new(10)
+    
+    # Wait for stale
+    time.sleep(1.5)
+    
+    # Start background calculations
+    def bg_old():
+        slow_func_old(10)
+    def bg_new():
+        slow_func_new(10)
+    
+    threading.Thread(target=bg_old).start()
+    threading.Thread(target=bg_new).start()
+    time.sleep(0.5)
+    
+    print("\nTesting behavior when calculation times out:")
+    
+    # Test old behavior
+    print("📊 OLD behavior (return_stale_on_timeout=False):")
+    start = time.time()
+    result_old = slow_func_old(10)  # Will wait, then start new calculation
+    elapsed_old = time.time() - start
+    print(f"   Result: {result_old}, Time: {elapsed_old:.2f}s")
+    
+    time.sleep(0.5)  # Brief pause
+    
+    # Test new behavior  
+    print("🆕 NEW behavior (return_stale_on_timeout=True):")
+    start = time.time()
+    result_new = slow_func_new(10)  # Will return stale value after timeout
+    elapsed_new = time.time() - start
+    print(f"   Result: {result_new}, Time: {elapsed_new:.2f}s")
+    
+    print(f"\n🏆 Time saved: {elapsed_old - elapsed_new:.2f} seconds!")
+
+
+if __name__ == "__main__":
+    demo_return_stale_on_timeout()
+    demo_comparison() 

--- a/src/cachier/config.py
+++ b/src/cachier/config.py
@@ -62,6 +62,7 @@ class Params:
     pickle_reload: bool = True
     separate_files: bool = False
     wait_for_calc_timeout: int = 0
+    return_stale_on_timeout: bool = False
     allow_none: bool = False
     cleanup_stale: bool = False
     cleanup_interval: timedelta = timedelta(days=1)
@@ -118,9 +119,10 @@ def set_global_params(**params: Any) -> None:
     Parameters given directly to a decorator take precedence over any values
     set by this function.
 
-    Only 'stale_after', 'next_time', and 'wait_for_calc_timeout' can be changed
-    after the memoization decorator has been applied. Other parameters will
-    only have an effect on decorators applied after this function is run.
+    Only 'stale_after', 'next_time', 'wait_for_calc_timeout', and 
+    'return_stale_on_timeout' can be changed after the memoization decorator 
+    has been applied. Other parameters will only have an effect on decorators 
+    applied after this function is run.
 
     """
     import cachier

--- a/src/cachier/cores/base.py
+++ b/src/cachier/cores/base.py
@@ -34,9 +34,11 @@ class _BaseCore:
         self,
         hash_func: Optional[HashFunc],
         wait_for_calc_timeout: Optional[int],
+        return_stale_on_timeout: Optional[bool] = None,
     ):
         self.hash_func = _update_with_defaults(hash_func, "hash_func")
         self.wait_for_calc_timeout = wait_for_calc_timeout
+        self.return_stale_on_timeout = return_stale_on_timeout
         self.lock = threading.RLock()
 
     def set_func(self, func):

--- a/src/cachier/cores/memory.py
+++ b/src/cachier/cores/memory.py
@@ -1,6 +1,7 @@
 """A memory-based caching core for cachier."""
 
 import threading
+import time
 from datetime import datetime, timedelta
 from typing import Any, Dict, Optional, Tuple
 
@@ -16,8 +17,9 @@ class _MemoryCore(_BaseCore):
         self,
         hash_func: Optional[HashFunc],
         wait_for_calc_timeout: Optional[int],
+        return_stale_on_timeout: Optional[bool] = None,
     ):
-        super().__init__(hash_func, wait_for_calc_timeout)
+        super().__init__(hash_func, wait_for_calc_timeout, return_stale_on_timeout)
         self.cache: Dict[str, CacheEntry] = {}
 
     def _hash_func_key(self, key: str) -> str:
@@ -89,10 +91,24 @@ class _MemoryCore(_BaseCore):
                 return entry.value
         if entry._condition is None:
             raise RuntimeError("No condition set for entry")
-        entry._condition.acquire()
-        entry._condition.wait()
-        entry._condition.release()
-        return self.cache[hash_key].value
+        
+        # Wait with timeout checking similar to other cores
+        time_spent = 0
+        while True:
+            entry._condition.acquire()
+            # Wait for 1 second at a time to allow timeout checking
+            signaled = entry._condition.wait(timeout=1.0)
+            entry._condition.release()
+            
+            # Check if the calculation completed
+            with self.lock:
+                if hash_key in self.cache and not self.cache[hash_key]._processing:
+                    return self.cache[hash_key].value
+            
+            # If we weren't signaled and the entry is still processing, check timeout
+            if not signaled:
+                time_spent += 1
+                self.check_calc_timeout(time_spent)
 
     def clear_cache(self) -> None:
         with self.lock:

--- a/src/cachier/cores/mongo.py
+++ b/src/cachier/cores/mongo.py
@@ -40,6 +40,7 @@ class _MongoCore(_BaseCore):
         hash_func: Optional[HashFunc],
         mongetter: Optional[Mongetter],
         wait_for_calc_timeout: Optional[int],
+        return_stale_on_timeout: Optional[bool] = None,
     ):
         if "pymongo" not in sys.modules:
             warnings.warn(
@@ -49,7 +50,7 @@ class _MongoCore(_BaseCore):
             )  # pragma: no cover
 
         super().__init__(
-            hash_func=hash_func, wait_for_calc_timeout=wait_for_calc_timeout
+            hash_func=hash_func, wait_for_calc_timeout=wait_for_calc_timeout, return_stale_on_timeout=return_stale_on_timeout
         )
         if mongetter is None:
             raise MissingMongetter(

--- a/src/cachier/cores/pickle.py
+++ b/src/cachier/cores/pickle.py
@@ -78,8 +78,9 @@ class _PickleCore(_BaseCore):
         cache_dir: Optional[Union[str, os.PathLike]],
         separate_files: Optional[bool],
         wait_for_calc_timeout: Optional[int],
+        return_stale_on_timeout: Optional[bool] = None,
     ):
-        super().__init__(hash_func, wait_for_calc_timeout)
+        super().__init__(hash_func, wait_for_calc_timeout, return_stale_on_timeout)
         self._cache_dict: Dict[str, CacheEntry] = {}
         self.reload = _update_with_defaults(pickle_reload, "pickle_reload")
         self.cache_dir = os.path.expanduser(

--- a/src/cachier/cores/redis.py
+++ b/src/cachier/cores/redis.py
@@ -34,6 +34,7 @@ class _RedisCore(_BaseCore):
             Union["redis.Redis", Callable[[], "redis.Redis"]]
         ],
         wait_for_calc_timeout: Optional[int] = None,
+        return_stale_on_timeout: Optional[bool] = None,
         key_prefix: str = "cachier",
     ):
         if not REDIS_AVAILABLE:
@@ -45,7 +46,7 @@ class _RedisCore(_BaseCore):
             )
 
         super().__init__(
-            hash_func=hash_func, wait_for_calc_timeout=wait_for_calc_timeout
+            hash_func=hash_func, wait_for_calc_timeout=wait_for_calc_timeout, return_stale_on_timeout=return_stale_on_timeout
         )
         if redis_client is None:
             raise MissingRedisClient(

--- a/src/cachier/cores/sql.py
+++ b/src/cachier/cores/sql.py
@@ -63,6 +63,7 @@ class _SQLCore(_BaseCore):
         hash_func: Optional[HashFunc],
         sql_engine: Optional[Union[str, "Engine", Callable[[], "Engine"]]],
         wait_for_calc_timeout: Optional[int] = None,
+        return_stale_on_timeout: Optional[bool] = None,
     ):
         if not SQLALCHEMY_AVAILABLE:
             raise ImportError(
@@ -70,7 +71,7 @@ class _SQLCore(_BaseCore):
                 "Install with `pip install SQLAlchemy`."
             )
         super().__init__(
-            hash_func=hash_func, wait_for_calc_timeout=wait_for_calc_timeout
+            hash_func=hash_func, wait_for_calc_timeout=wait_for_calc_timeout, return_stale_on_timeout=return_stale_on_timeout
         )
         self._engine = self._resolve_engine(sql_engine)
         self._Session = sessionmaker(bind=self._engine)

--- a/tests/test_return_stale_on_timeout.py
+++ b/tests/test_return_stale_on_timeout.py
@@ -1,0 +1,209 @@
+"""Test return_stale_on_timeout functionality."""
+
+import time
+import threading
+import queue
+from datetime import timedelta
+
+import pytest
+
+import cachier
+
+
+@pytest.mark.parametrize("backend", ["memory", "pickle"])
+def test_return_stale_on_timeout_true(backend):
+    """Test that stale values are returned when timeout expires and return_stale_on_timeout=True."""
+    
+    @cachier.cachier(
+        backend=backend,
+        stale_after=timedelta(seconds=1),
+        wait_for_calc_timeout=2,
+        return_stale_on_timeout=True,
+        next_time=False,
+    )
+    def slow_function(x):
+        time.sleep(3)  # Longer than wait_for_calc_timeout
+        return x * 2
+    
+    slow_function.clear_cache()
+    
+    # First call - will be cached
+    result1 = slow_function(5)
+    assert result1 == 10
+    
+    # Wait for value to become stale
+    time.sleep(1.5)
+    
+    # Start a background thread that will trigger recalculation
+    def background_call(result_queue):
+        result = slow_function(5)
+        result_queue.put(result)
+    
+    result_queue = queue.Queue()
+    thread1 = threading.Thread(target=background_call, args=(result_queue,))
+    thread1.start()
+    
+    # Give thread1 time to start the calculation
+    time.sleep(0.5)
+    
+    # This call should timeout waiting for the calculation and return stale value
+    start_time = time.time()
+    result2 = slow_function(5)
+    elapsed_time = time.time() - start_time
+    
+    # Should return quickly with stale value, not wait for full calculation
+    assert elapsed_time < 2.5  # Less than wait_for_calc_timeout + some buffer
+    assert result2 == 10  # Should return the stale value
+    
+    # Clean up
+    thread1.join(timeout=5)
+    if not result_queue.empty():
+        result_queue.get()
+
+
+@pytest.mark.parametrize("backend", ["memory", "pickle"]) 
+def test_return_stale_on_timeout_false(backend):
+    """Test that new calculation is triggered when timeout expires and return_stale_on_timeout=False."""
+    
+    @cachier.cachier(
+        backend=backend,
+        stale_after=timedelta(seconds=1),
+        wait_for_calc_timeout=2,
+        return_stale_on_timeout=False,  # Default behavior
+        next_time=False,
+    )
+    def slow_function(x):
+        time.sleep(3)  # Longer than wait_for_calc_timeout
+        return x * 3  # Different multiplier to distinguish results
+    
+    slow_function.clear_cache()
+    
+    # First call - will be cached
+    result1 = slow_function(5)
+    assert result1 == 15
+    
+    # Wait for value to become stale
+    time.sleep(1.5)
+    
+    # Start a background thread that will trigger recalculation
+    def background_call(result_queue):
+        result = slow_function(5)
+        result_queue.put(result)
+    
+    result_queue = queue.Queue()
+    thread1 = threading.Thread(target=background_call, args=(result_queue,))
+    thread1.start()
+    
+    # Give thread1 time to start the calculation
+    time.sleep(0.5)
+    
+    # This call should timeout waiting for the calculation and trigger a new calculation
+    start_time = time.time()
+    result2 = slow_function(5)
+    elapsed_time = time.time() - start_time
+    
+    # Should take about as long as the function execution time
+    assert elapsed_time >= 2.5  # At least close to the function execution time
+    assert result2 == 15  # Should return the newly calculated value
+    
+    # Clean up
+    thread1.join(timeout=8)
+    if not result_queue.empty():
+        result_queue.get()
+
+
+@pytest.mark.parametrize("backend", ["memory", "pickle"])
+def test_return_stale_on_timeout_no_stale_value(backend):
+    """Test that new calculation is triggered when no stale value exists, regardless of return_stale_on_timeout."""
+    
+    @cachier.cachier(
+        backend=backend,
+        wait_for_calc_timeout=2,
+        return_stale_on_timeout=True,
+        next_time=False,
+    )
+    def slow_function(x):
+        time.sleep(3)  # Longer than wait_for_calc_timeout
+        return x * 4
+    
+    slow_function.clear_cache()
+    
+    # Start two threads simultaneously - no cached value exists
+    def background_call(result_queue, thread_id):
+        result = slow_function(5)
+        result_queue.put((thread_id, result))
+    
+    result_queue = queue.Queue()
+    thread1 = threading.Thread(target=background_call, args=(result_queue, 1))
+    thread2 = threading.Thread(target=background_call, args=(result_queue, 2))
+    
+    thread1.start()
+    time.sleep(0.1)  # Small delay to ensure thread1 starts first
+    thread2.start()
+    
+    # Wait for both threads to complete
+    thread1.join(timeout=8)
+    thread2.join(timeout=8)
+    
+    # Should get results from both threads
+    assert result_queue.qsize() == 2
+    results = []
+    while not result_queue.empty():
+        thread_id, result = result_queue.get()
+        results.append(result)
+    
+    # Both should have calculated the value (one calculated, one waited or recalculated)
+    assert all(result == 20 for result in results)
+
+
+def test_return_stale_on_timeout_global_config():
+    """Test that return_stale_on_timeout can be set globally."""
+    
+    # Set global configuration
+    cachier.set_global_params(
+        wait_for_calc_timeout=2,
+        return_stale_on_timeout=True
+    )
+    
+    @cachier.cachier(
+        backend="memory",
+        stale_after=timedelta(seconds=1),
+        next_time=False,
+    )
+    def slow_function(x):
+        time.sleep(3)
+        return x * 5
+    
+    slow_function.clear_cache()
+    
+    # First call - will be cached
+    result1 = slow_function(3)
+    assert result1 == 15
+    
+    # Wait for value to become stale
+    time.sleep(1.5)
+    
+    # Start background calculation
+    def background_call():
+        slow_function(3)
+    
+    thread1 = threading.Thread(target=background_call)
+    thread1.start()
+    time.sleep(0.5)  # Let background calculation start
+    
+    # This should return stale value due to global configuration
+    start_time = time.time()
+    result2 = slow_function(3)
+    elapsed_time = time.time() - start_time
+    
+    assert elapsed_time < 2.5  # Should return quickly
+    assert result2 == 15  # Should return stale value
+    
+    # Clean up
+    thread1.join(timeout=5)
+    
+    # Reset global configuration
+    cachier.set_global_params(
+        wait_for_calc_timeout=0,
+        return_stale_on_timeout=False
+    ) 


### PR DESCRIPTION
By @zscgeek:

> 
> feat: add return_stale_on_timeout parameter for stale-while-revalidate caching
> 
> Adds new `return_stale_on_timeout` parameter that enables returning stale 
> cached values when `wait_for_calc_timeout` expires, instead of triggering 
> a new calculation. This implements a stale-while-revalidate pattern that
> keeps applications responsive while ensuring background cache refresh.
> 
> Key changes:
> - Add return_stale_on_timeout parameter to all cache backends
> - Modify core logic to return stale values on RecalculationNeeded exception
> - Fix memory core timeout handling to properly check wait_for_calc_timeout
> - Add comprehensive test suite with 7 test cases
> - Update documentation and maintain backward compatibility
> 
> When enabled, the behavior follows this pattern:
> 1. Fresh values (≤ stale_after) return immediately
> 2. Stale values trigger background refresh
> 3. Caller waits up to wait_for_calc_timeout for refresh to complete
> 4. If timeout expires, return stale value instead of blocking
> 5. Background refresh continues for next request