### PR TITLE
Chore Dependabot settings to group GHA

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,15 +11,13 @@ updates:
     schedule:
       interval: "monthly"
     # Labels on pull requests for version updates only
-    labels: ["CI"]
+    labels: ["dependencies"]
     pull-request-branch-name:
       # Separate sections of the branch name with a hyphen
       # for example, `dependabot-npm_and_yarn-next_js-acorn-6.4.1`
       separator: "-"
     # Allow up to 5 open pull requests for pip dependencies
     open-pull-requests-limit: 5
-    reviewers:
-      - "borda"
 
   # Enable version updates for GitHub Actions
   - package-ecosystem: "github-actions"
@@ -30,10 +28,9 @@ updates:
     # Labels on pull requests for version updates only
     labels: ["CI"]
     pull-request-branch-name:
-      # Separate sections of the branch name with a hyphen
-      # for example, `dependabot-npm_and_yarn-next_js-acorn-6.4.1`
       separator: "-"
-    # Allow up to 5 open pull requests for GitHub Actions
-    open-pull-requests-limit: 5
-    reviewers:
-      - "borda"
+    open-pull-requests-limit: 1
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
This pull request updates the Dependabot configuration to better organize dependency update pull requests and streamline their management. The main changes involve adjusting labels, limiting the number of open pull requests, and grouping updates for GitHub Actions.

**Dependabot configuration improvements:**

* Changed the label for dependency update pull requests from `"CI"` to `"dependencies"` to more accurately reflect their purpose.
* Removed deprecated `reviewers` field so that pull requests are no longer automatically assigned to `"borda"`. [[1]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L14-L22) [[2]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L33-R36)

**GitHub Actions update management:**

* Reduced the maximum number of open pull requests for GitHub Actions from 5 to 1, helping to avoid PR clutter.
* Introduced grouping for GitHub Actions updates using the `groups` key, so related updates are bundled together.