### PR TITLE
Update dependency file paths and simplify CI workflow steps

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -55,10 +55,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
 
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install -e .
+      - name: Install package & dependencies
+        run: python -m pip install -e . -r tests/requirements.txt
 
       - name: Lower inotify instance limit (Linux only, for Issue #24 test)
         if: runner.os == 'Linux' && matrix.backend == 'local'
@@ -77,7 +75,7 @@ jobs:
           # For testcontainers to find the Colima socket
           sudo ln -sf $HOME/.colima/default/docker.sock /var/run/docker.sock
 
-      - name: Install test dependencies
+      - name: Install other test dependencies
         run: python -m pip install -e . -r tests/requirements_${{ matrix.backend }}.txt
 
       # ToDo: find a way to cache docker images

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -76,6 +76,7 @@ jobs:
           sudo ln -sf $HOME/.colima/default/docker.sock /var/run/docker.sock
 
       - name: Install other test dependencies
+        if: matrix.backend != 'local'
         run: python -m pip install -e . -r tests/requirements_${{ matrix.backend }}.txt
 
       # ToDo: find a way to cache docker images

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -53,11 +53,12 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
+          cache: "pip"
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e . -r tests/requirements.txt
+          python -m pip install -e .
 
       - name: Lower inotify instance limit (Linux only, for Issue #24 test)
         if: runner.os == 'Linux' && matrix.backend == 'local'
@@ -75,6 +76,10 @@ jobs:
           colima start
           # For testcontainers to find the Colima socket
           sudo ln -sf $HOME/.colima/default/docker.sock /var/run/docker.sock
+
+      - name: Install test dependencies
+        run: python -m pip install -e . -r tests/requirements_${{ matrix.backend }}.txt
+
       # ToDo: find a way to cache docker images
       #- name: Cache Container Images
       #  if: matrix.backend == 'mongodb'
@@ -82,7 +87,6 @@ jobs:
       #  with:
       #    prefix-key: "mongo-db"
       #    images: mongo:latest
-
       - name: Start MongoDB in docker
         if: matrix.backend == 'mongodb'
         run: |
@@ -92,11 +96,6 @@ jobs:
           sleep 5
           # show running containers
           docker ps -a
-
-      - name: Install MongoDB core test dependencies
-        if: matrix.backend == 'mongodb'
-        run: |
-          python -m pip install -e . -r tests/mongodb_requirements.txt
 
       - name: Unit tests (DB)
         if: matrix.backend == 'mongodb'
@@ -117,11 +116,6 @@ jobs:
           sleep 10
           docker ps -a
 
-      - name: Install SQL core test dependencies (SQL/Postgres)
-        if: matrix.backend == 'postgres'
-        run: |
-          python -m pip install -e . -r tests/sql_requirements.txt
-
       - name: Unit tests (SQL/Postgres)
         if: matrix.backend == 'postgres'
         env:
@@ -137,11 +131,6 @@ jobs:
           # wait for Redis to start
           sleep 5
           docker ps -a
-
-      - name: Install Redis core test dependencies
-        if: matrix.backend == 'redis'
-        run: |
-          python -m pip install -e . -r tests/redis_requirements.txt
 
       - name: Unit tests (Redis)
         if: matrix.backend == 'redis'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -406,9 +406,9 @@ ______________________________________________________________________
   pip install -e .
   pip install -r tests/requirements.txt
   # For specific backends:
-  pip install -r tests/mongodb_requirements.txt
-  pip install -r tests/redis_requirements.txt
-  pip install -r tests/sql_requirements.txt
+  pip install -r tests/requirements_mongodb.txt
+  pip install -r tests/requirements_redis.txt
+  pip install -r tests/requirements_postgres.txt
   ```
 - **Run all tests:** `pytest`
 - **Run backend-specific tests:** `pytest -m <backend>` (mongo, redis, sql, memory, pickle, maxage)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ cachier/
 │   └── __main__.py
 ├── tests/                 # Pytest-based tests, backend-marked
 │   ├── test_*.py
-│   └── *_requirements.txt # Backend-specific test requirements
+│   └── requirements_*.txt # Backend-specific test requirements
 ├── examples/              # Usage examples
 ├── README.rst             # Main documentation
 ├── pyproject.toml         # Build, lint, type, test config
@@ -55,7 +55,7 @@ ______________________________________________________________________
    pip install .[all]
    ```
 
-   - For backend-specific dev: see `tests/*_requirements.txt`.
+   - For backend-specific dev: see `tests/requirements_*.txt`.
 
 2. **Run tests:**
 
@@ -111,7 +111,7 @@ ______________________________________________________________________
 - **Default:** Pickle (local file cache, `~/.cachier/`)
 - **Others:** Memory, MongoDB, SQL, Redis
 - **Adding a backend:** Implement in `src/cachier/cores/`, subclass `BaseCore`, add tests with appropriate markers, update docs, and CI matrix if needed.
-- **Optional dependencies:** Code/tests must gracefully skip if backend deps are missing. Install backend-specific deps via `tests/*_requirements.txt`.
+- **Optional dependencies:** Code/tests must gracefully skip if backend deps are missing. Install backend-specific deps via `tests/requirements_*.txt`.
 - **Requirements files:** `tests/sql_requirements.txt`, `tests/redis_requirements.txt` for backend-specific dependencies.
 
 ### 3. **Decorator Usage**
@@ -125,7 +125,7 @@ ______________________________________________________________________
 - **Run all tests:** `pytest`
 - **Backend-specific:** Use markers, e.g. `pytest -m mongo`, `pytest -m redis`, `pytest -m sql`
 - **Available markers:** `mongo`, `memory`, `pickle`, `redis`, `sql`, `maxage` (see `pyproject.toml`)
-- **Requirements:** See `tests/*_requirements.txt` for backend test deps.
+- **Requirements:** See `tests/requirements_*.txt` for backend test deps.
 - **CI:** Matrix covers OS/backend combinations. Mongo/SQL/Redis require Dockerized services.
 - **Missing deps:** Tests gracefully skip if optional backend dependencies are missing.
 
@@ -421,7 +421,7 @@ ______________________________________________________________________
 - **Build package:** `python -m build`
 - **Check docs:** `python setup.py checkdocs`
 - **Run example:** `python examples/redis_example.py`
-- **Update requirements:** Edit `tests/*_requirements.txt` as needed (sql_requirements.txt, redis_requirements.txt).
+- **Update requirements:** Edit `tests/requirements_*.txt` as needed (sql_requirements.txt, redis_requirements.txt).
 
 ### Local Testing with Docker
 
@@ -488,7 +488,7 @@ ______________________________________________________________________
 
 ### b. **Best Practices for Coding Assistance Agents**
 
-- **Always check for backend-specific requirements** before running backend tests or code (see `tests/*_requirements.txt`).
+- **Always check for backend-specific requirements** before running backend tests or code (see `tests/requirements_*.txt`).
 - **When adding a backend:** Update all relevant places (core, tests, docs, CI matrix, requirements files).
 - **When editing core logic:** Ensure all backends are still supported and tested.
 - **When updating the decorator API:** Update docstrings, README, and tests.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -406,9 +406,9 @@ ______________________________________________________________________
   pip install -e .
   pip install -r tests/requirements.txt
   # For specific backends:
-  pip install -r tests/mongodb_requirements.txt
-  pip install -r tests/redis_requirements.txt
-  pip install -r tests/sql_requirements.txt
+  pip install -r tests/requirements_mongodb.txt
+  pip install -r tests/requirements_redis.txt
+  pip install -r tests/requirements_postgres.txt
   ```
 - **Run all tests:** `pytest`
 - **Run backend-specific tests:** `pytest -m <backend>` (mongo, redis, sql, memory, pickle, maxage)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ cachier/
 │   └── __main__.py
 ├── tests/                 # Pytest-based tests, backend-marked
 │   ├── test_*.py
-│   └── *_requirements.txt # Backend-specific test requirements
+│   └── requirements_*.txt # Backend-specific test requirements
 ├── examples/              # Usage examples
 ├── README.rst             # Main documentation
 ├── pyproject.toml         # Build, lint, type, test config
@@ -55,7 +55,7 @@ ______________________________________________________________________
    pip install .[all]
    ```
 
-   - For backend-specific dev: see `tests/*_requirements.txt`.
+   - For backend-specific dev: see `tests/requirements_*.txt`.
 
 2. **Run tests:**
 
@@ -111,7 +111,7 @@ ______________________________________________________________________
 - **Default:** Pickle (local file cache, `~/.cachier/`)
 - **Others:** Memory, MongoDB, SQL, Redis
 - **Adding a backend:** Implement in `src/cachier/cores/`, subclass `BaseCore`, add tests with appropriate markers, update docs, and CI matrix if needed.
-- **Optional dependencies:** Code/tests must gracefully skip if backend deps are missing. Install backend-specific deps via `tests/*_requirements.txt`.
+- **Optional dependencies:** Code/tests must gracefully skip if backend deps are missing. Install backend-specific deps via `tests/requirements_*.txt`.
 - **Requirements files:** `tests/sql_requirements.txt`, `tests/redis_requirements.txt` for backend-specific dependencies.
 
 ### 3. **Decorator Usage**
@@ -125,7 +125,7 @@ ______________________________________________________________________
 - **Run all tests:** `pytest`
 - **Backend-specific:** Use markers, e.g. `pytest -m mongo`, `pytest -m redis`, `pytest -m sql`
 - **Available markers:** `mongo`, `memory`, `pickle`, `redis`, `sql`, `maxage` (see `pyproject.toml`)
-- **Requirements:** See `tests/*_requirements.txt` for backend test deps.
+- **Requirements:** See `tests/requirements_*.txt` for backend test deps.
 - **CI:** Matrix covers OS/backend combinations. Mongo/SQL/Redis require Dockerized services.
 - **Missing deps:** Tests gracefully skip if optional backend dependencies are missing.
 
@@ -421,7 +421,7 @@ ______________________________________________________________________
 - **Build package:** `python -m build`
 - **Check docs:** `python setup.py checkdocs`
 - **Run example:** `python examples/redis_example.py`
-- **Update requirements:** Edit `tests/*_requirements.txt` as needed (sql_requirements.txt, redis_requirements.txt).
+- **Update requirements:** Edit `tests/requirements_*.txt` as needed (sql_requirements.txt, redis_requirements.txt).
 
 ### Local Testing with Docker
 
@@ -488,7 +488,7 @@ ______________________________________________________________________
 
 ### b. **Best Practices for Claude**
 
-- **Always check for backend-specific requirements** before running backend tests or code (see `tests/*_requirements.txt`).
+- **Always check for backend-specific requirements** before running backend tests or code (see `tests/requirements_*.txt`).
 - **When adding a backend:** Update all relevant places (core, tests, docs, CI matrix, requirements files).
 - **When editing core logic:** Ensure all backends are still supported and tested.
 - **When updating the decorator API:** Update docstrings, README, and tests.

--- a/scripts/README-local-testing.md
+++ b/scripts/README-local-testing.md
@@ -154,9 +154,9 @@ The script automatically sets the required environment variables:
 2. **Python dependencies** - Install test requirements:
    ```bash
    pip install -r tests/requirements.txt
-   pip install -r tests/mongodb_requirements.txt  # For MongoDB tests
-   pip install -r tests/redis_requirements.txt    # For Redis tests
-   pip install -r tests/sql_requirements.txt      # For SQL tests
+   pip install -r tests/requirements_mongodb.txt  # For MongoDB tests
+   pip install -r tests/requirements_redis.txt    # For Redis tests
+   pip install -r tests/requirements_postgres.txt      # For SQL tests
    ```
 
 ## Troubleshooting

--- a/tests/requirements_mongodb.txt
+++ b/tests/requirements_mongodb.txt
@@ -1,4 +1,4 @@
-
+-r requirements.txt
 # to connect to the test mongodb server
 pymongo
 dnspython

--- a/tests/requirements_postgres.txt
+++ b/tests/requirements_postgres.txt
@@ -1,3 +1,4 @@
+-r requirements.txt
 # for SQL core tests
 SQLAlchemy
 psycopg2-binary

--- a/tests/requirements_redis.txt
+++ b/tests/requirements_redis.txt
@@ -1,3 +1,5 @@
+-r requirements.txt
+
 redis>=4.0.0
 pandas>=1.3.0
 birch>=0.0.35


### PR DESCRIPTION
This pull request refactors how test dependencies are managed for different backends (MongoDB, Redis, Postgres/SQL) by standardizing requirements file naming and updating the CI workflow accordingly. The changes improve clarity, maintainability, and consistency across documentation and automation scripts.

**Test dependency management improvements:**

* Renamed backend-specific requirements files in `tests/` to `requirements_mongodb.txt`, `requirements_redis.txt`, and `requirements_postgres.txt`, and updated their contents to include a reference to `requirements.txt` for shared dependencies. [[1]](diffhunk://#diff-01373f974a3e257d099b135f7d0810aeeeb7da0343906f69d2d5a27ee0d33a54L1-R1) [[2]](diffhunk://#diff-ec5caccb706f2583f6c6f52382475192323ca170c46987fcac6df3306c77101dR1-R2) [[3]](diffhunk://#diff-4f9787ddf2e7240bbaaeaf3f81a22f246ac465743d39fe9f1389b40688a35ceaR1)
* Updated the CI workflow in `.github/workflows/ci-test.yml` to install backend-specific test dependencies using the new requirements file names, and consolidated dependency installation steps for clarity. [[1]](diffhunk://#diff-ffc5a51e3c0c30ff89670916d7bfd5a86b132b62831532905182b28601cac8eaR56-R61) [[2]](diffhunk://#diff-ffc5a51e3c0c30ff89670916d7bfd5a86b132b62831532905182b28601cac8eaR79-L85) [[3]](diffhunk://#diff-ffc5a51e3c0c30ff89670916d7bfd5a86b132b62831532905182b28601cac8eaL96-L100) [[4]](diffhunk://#diff-ffc5a51e3c0c30ff89670916d7bfd5a86b132b62831532905182b28601cac8eaL120-L124) [[5]](diffhunk://#diff-ffc5a51e3c0c30ff89670916d7bfd5a86b132b62831532905182b28601cac8eaL141-L145)

**Documentation updates:**

* Updated references to backend-specific requirements files in `AGENTS.md`, `CLAUDE.md`, and `scripts/README-local-testing.md` to use the new standardized file names. [[1]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L409-R411) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L409-R411) [[3]](diffhunk://#diff-d7e471a096e1ce02ef3fd0cebd6c57cb455657699ccbd3f5f67e98d7b3f1eaf1L157-R159)