### PR TITLE
Chore linting with 120 line-length

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
       - id: mdformat
         additional_dependencies:
           - mdformat-gfm
-          - mdformat-black
+          - mdformat-ruff
           - mdformat_frontmatter
         args: ["--number"]
 
@@ -61,7 +61,7 @@ repos:
       - id: ruff-format
         name: Black by Ruff
       # basic check
-      - id: ruff
+      - id: ruff-check
         name: Ruff check
         args: ["--fix"] #, "--unsafe-fixes"
 

--- a/examples/redis_example.py
+++ b/examples/redis_example.py
@@ -113,9 +113,7 @@ def demo_callable_client():
 
     def get_redis_client():
         """Get a Redis client."""
-        return redis.Redis(
-            host="localhost", port=6379, db=0, decode_responses=False
-        )
+        return redis.Redis(host="localhost", port=6379, db=0, decode_responses=False)
 
     @cachier(backend="redis", redis_client=get_redis_client)
     def cached_with_callable(n):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,14 +72,11 @@ namespaces = false # to disable scanning PEP 420 namespaces (true by default)
 
 # === Linting & Formatting ===
 
-[tool.black]
-line-length = 79
-
 # --- ruff ---
 
 [tool.ruff]
 target-version = "py39"
-line-length = 79
+line-length = 120
 # Exclude a variety of commonly ignored directories.
 exclude = [
   ".eggs",

--- a/src/cachier/config.py
+++ b/src/cachier/config.py
@@ -136,10 +136,7 @@ def set_global_params(**params: Any) -> None:
     import cachier
 
     valid_params = {k: v for k, v in params.items() if hasattr(cachier.config._global_params, k)}
-    cachier.config._global_params = replace(
-        cachier.config._global_params,
-        **valid_params,
-    )
+    cachier.config._global_params = replace(cachier.config._global_params, **valid_params)
 
 
 def get_default_params() -> Params:

--- a/src/cachier/config.py
+++ b/src/cachier/config.py
@@ -83,9 +83,7 @@ class CacheEntry:
     _completed: bool = False
 
 
-def _update_with_defaults(
-    param, name: str, func_kwargs: Optional[dict] = None
-):
+def _update_with_defaults(param, name: str, func_kwargs: Optional[dict] = None):
     import cachier
 
     if func_kwargs:
@@ -107,8 +105,7 @@ def set_default_params(**params: Any) -> None:
     import warnings
 
     warnings.warn(
-        "Called `set_default_params` is deprecated and will be removed."
-        " Please use `set_global_params` instead.",
+        "Called `set_default_params` is deprecated and will be removed. Please use `set_global_params` instead.",
         DeprecationWarning,
         stacklevel=2,
     )
@@ -138,11 +135,7 @@ def set_global_params(**params: Any) -> None:
     """
     import cachier
 
-    valid_params = {
-        k: v
-        for k, v in params.items()
-        if hasattr(cachier.config._global_params, k)
-    }
+    valid_params = {k: v for k, v in params.items() if hasattr(cachier.config._global_params, k)}
     cachier.config._global_params = replace(
         cachier.config._global_params,
         **valid_params,
@@ -159,8 +152,7 @@ def get_default_params() -> Params:
     import warnings
 
     warnings.warn(
-        "Called `get_default_params` is deprecated and will be removed."
-        " Please use `get_global_params` instead.",
+        "Called `get_default_params` is deprecated and will be removed. Please use `get_global_params` instead.",
         DeprecationWarning,
         stacklevel=2,
     )

--- a/src/cachier/core.py
+++ b/src/cachier/core.py
@@ -56,9 +56,7 @@ def _function_thread(core, key, func, args, kwds):
         print(f"Function call failed with the following exception:\n{exc}")
 
 
-def _calc_entry(
-    core, key, func, args, kwds, printer=lambda *_: None
-) -> Optional[Any]:
+def _calc_entry(core, key, func, args, kwds, printer=lambda *_: None) -> Optional[Any]:
     core.mark_entry_being_calculated(key)
     try:
         func_res = func(*args, **kwds)
@@ -70,9 +68,7 @@ def _calc_entry(
         core.mark_entry_not_calculated(key)
 
 
-def _convert_args_kwargs(
-    func, _is_method: bool, args: tuple, kwds: dict
-) -> dict:
+def _convert_args_kwargs(func, _is_method: bool, args: tuple, kwds: dict) -> dict:
     """Convert mix of positional and keyword arguments to aggregated kwargs."""
     # unwrap if the function is functools.partial
     if hasattr(func, "func"):
@@ -80,16 +76,10 @@ def _convert_args_kwargs(
         kwds.update({k: v for k, v in func.keywords.items() if k not in kwds})
         func = func.func
     func_params = list(inspect.signature(func).parameters)
-    args_as_kw = dict(
-        zip(func_params[1:], args[1:])
-        if _is_method
-        else zip(func_params, args)
-    )
+    args_as_kw = dict(zip(func_params[1:], args[1:]) if _is_method else zip(func_params, args))
     # init with default values
     kwargs = {
-        k: v.default
-        for k, v in inspect.signature(func).parameters.items()
-        if v.default is not inspect.Parameter.empty
+        k: v.default for k, v in inspect.signature(func).parameters.items() if v.default is not inspect.Parameter.empty
     }
     # merge args expanded as kwargs and the original kwds
     kwargs.update(dict(**args_as_kw, **kwds))
@@ -99,8 +89,7 @@ def _convert_args_kwargs(
 def _pop_kwds_with_deprecation(kwds, name: str, default_value: bool):
     if name in kwds:
         warnings.warn(
-            f"`{name}` is deprecated and will be removed in a future release,"
-            " use `cachier__` alternative instead.",
+            f"`{name}` is deprecated and will be removed in a future release, use `cachier__` alternative instead.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -201,18 +190,13 @@ def cachier(
     """
     # Check for deprecated parameters
     if hash_params is not None:
-        message = (
-            "hash_params will be removed in a future release, "
-            "please use hash_func instead"
-        )
+        message = "hash_params will be removed in a future release, please use hash_func instead"
         warn(message, DeprecationWarning, stacklevel=2)
         hash_func = hash_params
     # Update parameters with defaults if input is None
     backend = _update_with_defaults(backend, "backend")
     mongetter = _update_with_defaults(mongetter, "mongetter")
-    size_limit_bytes = parse_bytes(
-        _update_with_defaults(entry_size_limit, "entry_size_limit")
-    )
+    size_limit_bytes = parse_bytes(_update_with_defaults(entry_size_limit, "entry_size_limit"))
     # Override the backend parameter if a mongetter is provided.
     if callable(mongetter):
         backend = "mongo"
@@ -290,41 +274,25 @@ def cachier(
             nonlocal allow_none, last_cleanup
             _allow_none = _update_with_defaults(allow_none, "allow_none", kwds)
             # print('Inside general wrapper for {}.'.format(func.__name__))
-            ignore_cache = _pop_kwds_with_deprecation(
-                kwds, "ignore_cache", False
-            )
-            overwrite_cache = _pop_kwds_with_deprecation(
-                kwds, "overwrite_cache", False
-            )
+            ignore_cache = _pop_kwds_with_deprecation(kwds, "ignore_cache", False)
+            overwrite_cache = _pop_kwds_with_deprecation(kwds, "overwrite_cache", False)
             verbose = _pop_kwds_with_deprecation(kwds, "verbose_cache", False)
             ignore_cache = kwds.pop("cachier__skip_cache", ignore_cache)
-            overwrite_cache = kwds.pop(
-                "cachier__overwrite_cache", overwrite_cache
-            )
+            overwrite_cache = kwds.pop("cachier__overwrite_cache", overwrite_cache)
             verbose = kwds.pop("cachier__verbose", verbose)
-            _stale_after = _update_with_defaults(
-                stale_after, "stale_after", kwds
-            )
+            _stale_after = _update_with_defaults(stale_after, "stale_after", kwds)
             _next_time = _update_with_defaults(next_time, "next_time", kwds)
-            _cleanup_flag = _update_with_defaults(
-                cleanup_stale, "cleanup_stale", kwds
-            )
-            _cleanup_interval_val = _update_with_defaults(
-                cleanup_interval, "cleanup_interval", kwds
-            )
+            _cleanup_flag = _update_with_defaults(cleanup_stale, "cleanup_stale", kwds)
+            _cleanup_interval_val = _update_with_defaults(cleanup_interval, "cleanup_interval", kwds)
             # merge args expanded as kwargs and the original kwds
-            kwargs = _convert_args_kwargs(
-                func, _is_method=core.func_is_method, args=args, kwds=kwds
-            )
+            kwargs = _convert_args_kwargs(func, _is_method=core.func_is_method, args=args, kwds=kwds)
 
             if _cleanup_flag:
                 now = datetime.now()
                 with cleanup_lock:
                     if now - last_cleanup >= _cleanup_interval_val:
                         last_cleanup = now
-                        _get_executor().submit(
-                            core.delete_stale_entries, _stale_after
-                        )
+                        _get_executor().submit(core.delete_stale_entries, _stale_after)
 
             _print = print if verbose else lambda x: None
 
@@ -332,17 +300,11 @@ def cachier(
             from .config import _global_params
 
             if ignore_cache or not _global_params.caching_enabled:
-                return (
-                    func(args[0], **kwargs)
-                    if core.func_is_method
-                    else func(**kwargs)
-                )
+                return func(args[0], **kwargs) if core.func_is_method else func(**kwargs)
             key, entry = core.get_entry((), kwargs)
             if overwrite_cache:
                 return _calc_entry(core, key, func, args, kwds, _print)
-            if entry is None or (
-                not entry._completed and not entry._processing
-            ):
+            if entry is None or (not entry._completed and not entry._processing):
                 _print("No entry found. No current calc. Calling like a boss.")
                 return _calc_entry(core, key, func, args, kwds, _print)
             _print("Entry found.")
@@ -353,10 +315,7 @@ def cachier(
                 nonneg_max_age = True
                 if max_age is not None:
                     if max_age < ZERO_TIMEDELTA:
-                        _print(
-                            "max_age is negative. "
-                            "Cached result considered stale."
-                        )
+                        _print("max_age is negative. Cached result considered stale.")
                         nonneg_max_age = False
                     else:
                         assert max_age is not None  # noqa: S101
@@ -379,9 +338,7 @@ def cachier(
                     _print("Async calc and return stale")
                     core.mark_entry_being_calculated(key)
                     try:
-                        _get_executor().submit(
-                            _function_thread, core, key, func, args, kwds
-                        )
+                        _get_executor().submit(_function_thread, core, key, func, args, kwds)
                     finally:
                         core.mark_entry_not_calculated(key)
                     return entry.value
@@ -426,9 +383,7 @@ def cachier(
 
             """
             # merge args expanded as kwargs and the original kwds
-            kwargs = _convert_args_kwargs(
-                func, _is_method=core.func_is_method, args=args, kwds=kwds
-            )
+            kwargs = _convert_args_kwargs(func, _is_method=core.func_is_method, args=args, kwds=kwds)
             return core.precache_value((), kwargs, value_to_cache)
 
         func_wrapper.clear_cache = _clear_cache

--- a/src/cachier/core.py
+++ b/src/cachier/core.py
@@ -219,9 +219,7 @@ def cachier(
         )
     elif backend == "memory":
         core = _MemoryCore(
-            hash_func=hash_func,
-            wait_for_calc_timeout=wait_for_calc_timeout,
-            entry_size_limit=size_limit_bytes,
+            hash_func=hash_func, wait_for_calc_timeout=wait_for_calc_timeout, entry_size_limit=size_limit_bytes
         )
     elif backend == "sql":
         core = _SQLCore(

--- a/src/cachier/cores/base.py
+++ b/src/cachier/cores/base.py
@@ -85,9 +85,7 @@ class _BaseCore(metaclass=abc.ABCMeta):
 
     def check_calc_timeout(self, time_spent):
         """Raise an exception if a recalculation is needed."""
-        calc_timeout = _update_with_defaults(
-            self.wait_for_calc_timeout, "wait_for_calc_timeout"
-        )
+        calc_timeout = _update_with_defaults(self.wait_for_calc_timeout, "wait_for_calc_timeout")
         if calc_timeout > 0 and (time_spent >= calc_timeout):
             raise RecalculationNeeded()
 

--- a/src/cachier/cores/memory.py
+++ b/src/cachier/cores/memory.py
@@ -24,9 +24,7 @@ class _MemoryCore(_BaseCore):
     def _hash_func_key(self, key: str) -> str:
         return f"{_get_func_str(self.func)}:{key}"
 
-    def get_entry_by_key(
-        self, key: str, reload=False
-    ) -> Tuple[str, Optional[CacheEntry]]:
+    def get_entry_by_key(self, key: str, reload=False) -> Tuple[str, Optional[CacheEntry]]:
         with self.lock:
             return key, self.cache.get(self._hash_func_key(key), None)
 
@@ -112,8 +110,6 @@ class _MemoryCore(_BaseCore):
         """Remove stale entries from the in-memory cache."""
         now = datetime.now()
         with self.lock:
-            keys_to_delete = [
-                k for k, v in self.cache.items() if now - v.time > stale_after
-            ]
+            keys_to_delete = [k for k, v in self.cache.items() if now - v.time > stale_after]
             for key in keys_to_delete:
                 del self.cache[key]

--- a/src/cachier/cores/mongo.py
+++ b/src/cachier/cores/mongo.py
@@ -55,9 +55,7 @@ class _MongoCore(_BaseCore):
             entry_size_limit=entry_size_limit,
         )
         if mongetter is None:
-            raise MissingMongetter(
-                "must specify ``mongetter`` when using the mongo core"
-            )
+            raise MissingMongetter("must specify ``mongetter`` when using the mongo core")
         self.mongetter = mongetter
         self.mongo_collection = self.mongetter()
         index_inf = self.mongo_collection.index_information()
@@ -73,9 +71,7 @@ class _MongoCore(_BaseCore):
         return _get_func_str(self.func)
 
     def get_entry_by_key(self, key: str) -> Tuple[str, Optional[CacheEntry]]:
-        res = self.mongo_collection.find_one(
-            {"func": self._func_str, "key": key}
-        )
+        res = self.mongo_collection.find_one({"func": self._func_str, "key": key})
         if not res:
             return key, None
         val = None
@@ -156,6 +152,4 @@ class _MongoCore(_BaseCore):
     def delete_stale_entries(self, stale_after: timedelta) -> None:
         """Delete stale entries from the MongoDB cache."""
         threshold = datetime.now() - stale_after
-        self.mongo_collection.delete_many(
-            filter={"func": self._func_str, "time": {"$lt": threshold}}
-        )
+        self.mongo_collection.delete_many(filter={"func": self._func_str, "time": {"$lt": threshold}})

--- a/src/cachier/cores/mongo.py
+++ b/src/cachier/cores/mongo.py
@@ -142,10 +142,7 @@ class _MongoCore(_BaseCore):
 
     def clear_being_calculated(self) -> None:
         self.mongo_collection.update_many(
-            filter={
-                "func": self._func_str,
-                "processing": True,
-            },
+            filter={"func": self._func_str, "processing": True},
             update={"$set": {"processing": False}},
         )
 

--- a/src/cachier/cores/pickle.py
+++ b/src/cachier/cores/pickle.py
@@ -83,12 +83,8 @@ class _PickleCore(_BaseCore):
         super().__init__(hash_func, wait_for_calc_timeout, entry_size_limit)
         self._cache_dict: Dict[str, CacheEntry] = {}
         self.reload = _update_with_defaults(pickle_reload, "pickle_reload")
-        self.cache_dir = os.path.expanduser(
-            _update_with_defaults(cache_dir, "cache_dir")
-        )
-        self.separate_files = _update_with_defaults(
-            separate_files, "separate_files"
-        )
+        self.cache_dir = os.path.expanduser(_update_with_defaults(cache_dir, "cache_dir"))
+        self.separate_files = _update_with_defaults(separate_files, "separate_files")
         self._cache_used_fpath = ""
 
     @property
@@ -99,9 +95,7 @@ class _PickleCore(_BaseCore):
     @property
     def cache_fpath(self) -> str:
         os.makedirs(self.cache_dir, exist_ok=True)
-        return os.path.abspath(
-            os.path.join(os.path.realpath(self.cache_dir), self.cache_fname)
-        )
+        return os.path.abspath(os.path.join(os.path.realpath(self.cache_dir), self.cache_fname))
 
     @staticmethod
     def _convert_legacy_cache_entry(
@@ -124,10 +118,7 @@ class _PickleCore(_BaseCore):
             self._cache_used_fpath = str(self.cache_fpath)
         except (FileNotFoundError, EOFError):
             cache = {}
-        return {
-            k: _PickleCore._convert_legacy_cache_entry(v)
-            for k, v in cache.items()
-        }
+        return {k: _PickleCore._convert_legacy_cache_entry(v) for k, v in cache.items()}
 
     def get_cache_dict(self, reload: bool = False) -> Dict[str, CacheEntry]:
         if self._cache_used_fpath != self.cache_fpath:
@@ -140,9 +131,7 @@ class _PickleCore(_BaseCore):
             self._cache_dict = self._load_cache_dict()
         return self._cache_dict
 
-    def _load_cache_by_key(
-        self, key=None, hash_str=None
-    ) -> Optional[CacheEntry]:
+    def _load_cache_by_key(self, key=None, hash_str=None) -> Optional[CacheEntry]:
         fpath = self.cache_fpath
         fpath += f"_{hash_str or key}"
         try:
@@ -162,9 +151,7 @@ class _PickleCore(_BaseCore):
         path, name = os.path.split(self.cache_fpath)
         for subpath in os.listdir(path):
             if subpath.startswith(name):
-                entry = self._load_cache_by_key(
-                    hash_str=subpath.split("_")[-1]
-                )
+                entry = self._load_cache_by_key(hash_str=subpath.split("_")[-1])
                 if entry is not None:
                     entry._processing = False
                     self._save_cache(entry, hash_str=subpath.split("_")[-1])
@@ -176,9 +163,7 @@ class _PickleCore(_BaseCore):
         hash_str: Optional[str] = None,
     ) -> None:
         if separate_file_key and not isinstance(cache, CacheEntry):
-            raise ValueError(
-                "`separate_file_key` should only be used with a CacheEntry"
-            )
+            raise ValueError("`separate_file_key` should only be used with a CacheEntry")
         fpath = self.cache_fpath
         if separate_file_key is not None:
             fpath += f"_{separate_file_key}"
@@ -192,9 +177,7 @@ class _PickleCore(_BaseCore):
                 self._cache_dict = cache
                 self._cache_used_fpath = str(self.cache_fpath)
 
-    def get_entry_by_key(
-        self, key: str, reload: bool = False
-    ) -> Tuple[str, Optional[CacheEntry]]:
+    def get_entry_by_key(self, key: str, reload: bool = False) -> Tuple[str, Optional[CacheEntry]]:
         if self.separate_files:
             return key, self._load_cache_by_key(key)
         return key, self.get_cache_dict(reload).get(key)
@@ -313,9 +296,7 @@ class _PickleCore(_BaseCore):
 
     def _wait_with_inotify(self, key: str, filename: str) -> Any:  # type: ignore[valid-type]
         """Wait for calculation using inotify with proper cleanup."""
-        event_handler = _PickleCore.CacheChangeHandler(
-            filename=filename, core=self, key=key
-        )
+        event_handler = _PickleCore.CacheChangeHandler(filename=filename, core=self, key=key)
 
         observer = self._create_observer()
         event_handler.inject_observer(observer)
@@ -388,9 +369,7 @@ class _PickleCore(_BaseCore):
             for subpath in os.listdir(path):
                 if not subpath.startswith(f"{name}_"):
                     continue
-                entry = self._load_cache_by_key(
-                    hash_str=subpath.split("_")[-1]
-                )
+                entry = self._load_cache_by_key(hash_str=subpath.split("_")[-1])
                 if entry is not None and (now - entry.time > stale_after):
                     with suppress(FileNotFoundError):
                         os.remove(os.path.join(path, subpath))
@@ -398,9 +377,7 @@ class _PickleCore(_BaseCore):
 
         with self.lock:
             cache = self.get_cache_dict(reload=True)
-            keys_to_delete = [
-                k for k, v in cache.items() if now - v.time > stale_after
-            ]
+            keys_to_delete = [k for k, v in cache.items() if now - v.time > stale_after]
             for key in keys_to_delete:
                 del cache[key]
             self._save_cache(cache)

--- a/src/cachier/cores/pickle.py
+++ b/src/cachier/cores/pickle.py
@@ -204,12 +204,7 @@ class _PickleCore(_BaseCore):
 
     def mark_entry_being_calculated_separate_files(self, key: str) -> None:
         self._save_cache(
-            CacheEntry(
-                value=None,
-                time=datetime.now(),
-                stale=False,
-                _processing=True,
-            ),
+            CacheEntry(value=None, time=datetime.now(), stale=False, _processing=True),
             separate_file_key=key,
         )
 
@@ -230,12 +225,7 @@ class _PickleCore(_BaseCore):
             if key in cache:
                 cache[key]._processing = True
             else:
-                cache[key] = CacheEntry(
-                    value=None,
-                    time=datetime.now(),
-                    stale=False,
-                    _processing=True,
-                )
+                cache[key] = CacheEntry(value=None, time=datetime.now(), stale=False, _processing=True)
             self._save_cache(cache)
 
     def mark_entry_not_calculated(self, key: str) -> None:

--- a/src/cachier/cores/redis.py
+++ b/src/cachier/cores/redis.py
@@ -30,17 +30,14 @@ class _RedisCore(_BaseCore):
     def __init__(
         self,
         hash_func: Optional[HashFunc],
-        redis_client: Optional[
-            Union["redis.Redis", Callable[[], "redis.Redis"]]
-        ],
+        redis_client: Optional[Union["redis.Redis", Callable[[], "redis.Redis"]]],
         wait_for_calc_timeout: Optional[int] = None,
         key_prefix: str = "cachier",
         entry_size_limit: Optional[int] = None,
     ):
         if not REDIS_AVAILABLE:
             warnings.warn(
-                "`redis` was not found. Redis cores will not function. "
-                "Install with `pip install redis`.",
+                "`redis` was not found. Redis cores will not function. Install with `pip install redis`.",
                 ImportWarning,
                 stacklevel=2,
             )
@@ -51,9 +48,7 @@ class _RedisCore(_BaseCore):
             entry_size_limit=entry_size_limit,
         )
         if redis_client is None:
-            raise MissingRedisClient(
-                "must specify ``redis_client`` when using the redis core"
-            )
+            raise MissingRedisClient("must specify ``redis_client`` when using the redis core")
         self.redis_client = redis_client
         self.key_prefix = key_prefix
         self._func_str = None
@@ -147,11 +142,7 @@ class _RedisCore(_BaseCore):
                     timestamp_str = raw_ts.decode("latin-1", errors="ignore")
             else:
                 timestamp_str = str(raw_ts)
-            timestamp = (
-                datetime.fromisoformat(timestamp_str)
-                if timestamp_str
-                else datetime.now()
-            )
+            timestamp = datetime.fromisoformat(timestamp_str) if timestamp_str else datetime.now()
 
             stale = _RedisCore._get_bool_field(cached_data, "stale")
             processing = _RedisCore._get_bool_field(cached_data, "processing")
@@ -214,9 +205,7 @@ class _RedisCore(_BaseCore):
                 },
             )
         except Exception as e:
-            warnings.warn(
-                f"Redis mark_entry_being_calculated failed: {e}", stacklevel=2
-            )
+            warnings.warn(f"Redis mark_entry_being_calculated failed: {e}", stacklevel=2)
 
     def mark_entry_not_calculated(self, key: str) -> None:
         """Mark the entry mapped by the given key as not being calculated."""
@@ -226,9 +215,7 @@ class _RedisCore(_BaseCore):
         try:
             redis_client.hset(redis_key, "processing", "false")
         except Exception as e:
-            warnings.warn(
-                f"Redis mark_entry_not_calculated failed: {e}", stacklevel=2
-            )
+            warnings.warn(f"Redis mark_entry_not_calculated failed: {e}", stacklevel=2)
 
     def wait_on_entry_calc(self, key: str) -> Any:
         """Wait on the entry with keys being calculated and returns result."""
@@ -271,9 +258,7 @@ class _RedisCore(_BaseCore):
                     pipe.hset(key, "processing", "false")
                 pipe.execute()
         except Exception as e:
-            warnings.warn(
-                f"Redis clear_being_calculated failed: {e}", stacklevel=2
-            )
+            warnings.warn(f"Redis clear_being_calculated failed: {e}", stacklevel=2)
 
     def delete_stale_entries(self, stale_after: timedelta) -> None:
         """Remove stale entries from the Redis cache."""
@@ -297,13 +282,9 @@ class _RedisCore(_BaseCore):
                 try:
                     ts_val = datetime.fromisoformat(ts_s)
                 except Exception as exc:
-                    warnings.warn(
-                        f"Redis timestamp parse failed: {exc}", stacklevel=2
-                    )
+                    warnings.warn(f"Redis timestamp parse failed: {exc}", stacklevel=2)
                     continue
                 if ts_val < threshold:
                     redis_client.delete(key)
         except Exception as e:
-            warnings.warn(
-                f"Redis delete_stale_entries failed: {e}", stacklevel=2
-            )
+            warnings.warn(f"Redis delete_stale_entries failed: {e}", stacklevel=2)

--- a/src/cachier/cores/redis.py
+++ b/src/cachier/cores/redis.py
@@ -43,9 +43,7 @@ class _RedisCore(_BaseCore):
             )
 
         super().__init__(
-            hash_func=hash_func,
-            wait_for_calc_timeout=wait_for_calc_timeout,
-            entry_size_limit=entry_size_limit,
+            hash_func=hash_func, wait_for_calc_timeout=wait_for_calc_timeout, entry_size_limit=entry_size_limit
         )
         if redis_client is None:
             raise MissingRedisClient("must specify ``redis_client`` when using the redis core")
@@ -197,12 +195,7 @@ class _RedisCore(_BaseCore):
             now = datetime.now()
             redis_client.hset(
                 redis_key,
-                mapping={
-                    "timestamp": now.isoformat(),
-                    "stale": "false",
-                    "processing": "true",
-                    "completed": "false",
-                },
+                mapping={"timestamp": now.isoformat(), "stale": "false", "processing": "true", "completed": "false"},
             )
         except Exception as e:
             warnings.warn(f"Redis mark_entry_being_calculated failed: {e}", stacklevel=2)

--- a/src/cachier/cores/sql.py
+++ b/src/cachier/cores/sql.py
@@ -130,13 +130,7 @@ class _SQLCore(_BaseCore):
                     completed=True,
                 ).on_conflict_do_update(
                     index_elements=[CacheTable.function_id, CacheTable.key],
-                    set_={
-                        "value": thebytes,
-                        "timestamp": now,
-                        "stale": False,
-                        "processing": False,
-                        "completed": True,
-                    },
+                    set_={"value": thebytes, "timestamp": now, "stale": False, "processing": False, "completed": True},
                 )
                 if hasattr(base_insert, "on_conflict_do_update")
                 else None
@@ -156,19 +150,8 @@ class _SQLCore(_BaseCore):
                 if row:
                     session.execute(
                         update(CacheTable)
-                        .where(
-                            and_(
-                                CacheTable.function_id == self._func_str,
-                                CacheTable.key == key,
-                            )
-                        )
-                        .values(
-                            value=thebytes,
-                            timestamp=now,
-                            stale=False,
-                            processing=False,
-                            completed=True,
-                        )
+                        .where(and_(CacheTable.function_id == self._func_str, CacheTable.key == key))
+                        .values(value=thebytes, timestamp=now, stale=False, processing=False, completed=True)
                     )
                 else:
                     session.add(
@@ -199,12 +182,7 @@ class _SQLCore(_BaseCore):
             if row:
                 session.execute(
                     update(CacheTable)
-                    .where(
-                        and_(
-                            CacheTable.function_id == self._func_str,
-                            CacheTable.key == key,
-                        )
-                    )
+                    .where(and_(CacheTable.function_id == self._func_str, CacheTable.key == key))
                     .values(processing=True)
                 )
             else:
@@ -226,12 +204,7 @@ class _SQLCore(_BaseCore):
         with self._lock, self._Session() as session:
             session.execute(
                 update(CacheTable)
-                .where(
-                    and_(
-                        CacheTable.function_id == self._func_str,
-                        CacheTable.key == key,
-                    )
-                )
+                .where(and_(CacheTable.function_id == self._func_str, CacheTable.key == key))
                 .values(processing=False)
             )
             session.commit()
@@ -243,12 +216,7 @@ class _SQLCore(_BaseCore):
         while True:
             with self._lock, self._Session() as session:
                 row = session.execute(
-                    select(CacheTable).where(
-                        and_(
-                            CacheTable.function_id == self._func_str,
-                            CacheTable.key == key,
-                        )
-                    )
+                    select(CacheTable).where(and_(CacheTable.function_id == self._func_str, CacheTable.key == key))
                 ).scalar_one_or_none()
                 if not row:
                     raise RecalculationNeeded()
@@ -267,12 +235,7 @@ class _SQLCore(_BaseCore):
         with self._lock, self._Session() as session:
             session.execute(
                 update(CacheTable)
-                .where(
-                    and_(
-                        CacheTable.function_id == self._func_str,
-                        CacheTable.processing,
-                    )
-                )
+                .where(and_(CacheTable.function_id == self._func_str, CacheTable.processing))
                 .values(processing=False)
             )
             session.commit()

--- a/src/cachier/cores/sql.py
+++ b/src/cachier/cores/sql.py
@@ -46,9 +46,7 @@ if SQLALCHEMY_AVAILABLE:
         stale = Column(Boolean, default=False)
         processing = Column(Boolean, default=False)
         completed = Column(Boolean, default=False)
-        __table_args__ = (
-            Index("ix_func_key", "function_id", "key", unique=True),
-        )
+        __table_args__ = (Index("ix_func_key", "function_id", "key", unique=True),)
 
 
 class _SQLCore(_BaseCore):
@@ -66,10 +64,7 @@ class _SQLCore(_BaseCore):
         entry_size_limit: Optional[int] = None,
     ):
         if not SQLALCHEMY_AVAILABLE:
-            raise ImportError(
-                "SQLAlchemy is required for the SQL core. "
-                "Install with `pip install SQLAlchemy`."
-            )
+            raise ImportError("SQLAlchemy is required for the SQL core. Install with `pip install SQLAlchemy`.")
         super().__init__(
             hash_func=hash_func,
             wait_for_calc_timeout=wait_for_calc_timeout,
@@ -88,10 +83,7 @@ class _SQLCore(_BaseCore):
             return create_engine(sql_engine, future=True)
         if callable(sql_engine):
             return sql_engine()
-        raise ValueError(
-            "sql_engine must be a SQLAlchemy Engine, connection string, "
-            "or callable returning an Engine."
-        )
+        raise ValueError("sql_engine must be a SQLAlchemy Engine, connection string, or callable returning an Engine.")
 
     def set_func(self, func):
         super().set_func(func)
@@ -261,22 +253,14 @@ class _SQLCore(_BaseCore):
                 if not row:
                     raise RecalculationNeeded()
                 if not row.processing:
-                    return (
-                        pickle.loads(row.value)
-                        if row.value is not None
-                        else None
-                    )
+                    return pickle.loads(row.value) if row.value is not None else None
             time.sleep(1)
             time_spent += 1
             self.check_calc_timeout(time_spent)
 
     def clear_cache(self) -> None:
         with self._lock, self._Session() as session:
-            session.execute(
-                delete(CacheTable).where(
-                    CacheTable.function_id == self._func_str
-                )
-            )
+            session.execute(delete(CacheTable).where(CacheTable.function_id == self._func_str))
             session.commit()
 
     def clear_being_calculated(self) -> None:

--- a/tests/test_base_core.py
+++ b/tests/test_base_core.py
@@ -44,9 +44,7 @@ class ConcreteCachingCore(_BaseCore):
 def test_estimate_size_fallback():
     """Test _estimate_size falls back to sys.getsizeof when asizeof fails."""
     # Test lines 101-102: exception handling in _estimate_size
-    core = ConcreteCachingCore(
-        hash_func=None, wait_for_calc_timeout=10, entry_size_limit=1000
-    )
+    core = ConcreteCachingCore(hash_func=None, wait_for_calc_timeout=10, entry_size_limit=1000)
 
     # Mock asizeof to raise exception
     with patch(
@@ -61,9 +59,7 @@ def test_estimate_size_fallback():
 def test_should_store_exception():
     """Test _should_store returns True when size estimation fails."""
     # Test lines 109-110: exception handling in _should_store
-    core = ConcreteCachingCore(
-        hash_func=None, wait_for_calc_timeout=10, entry_size_limit=1000
-    )
+    core = ConcreteCachingCore(hash_func=None, wait_for_calc_timeout=10, entry_size_limit=1000)
 
     # Mock both size estimation methods to fail
     patch1 = patch(

--- a/tests/test_base_core.py
+++ b/tests/test_base_core.py
@@ -47,10 +47,7 @@ def test_estimate_size_fallback():
     core = ConcreteCachingCore(hash_func=None, wait_for_calc_timeout=10, entry_size_limit=1000)
 
     # Mock asizeof to raise exception
-    with patch(
-        "cachier.cores.base.asizeof.asizeof",
-        side_effect=Exception("asizeof failed"),
-    ):
+    with patch("cachier.cores.base.asizeof.asizeof", side_effect=Exception("asizeof failed")):
         # Should fall back to sys.getsizeof
         size = core._estimate_size("test_value")
         assert size > 0  # sys.getsizeof should return a positive value
@@ -62,10 +59,7 @@ def test_should_store_exception():
     core = ConcreteCachingCore(hash_func=None, wait_for_calc_timeout=10, entry_size_limit=1000)
 
     # Mock both size estimation methods to fail
-    patch1 = patch(
-        "cachier.cores.base.asizeof.asizeof",
-        side_effect=Exception("asizeof failed"),
-    )
+    patch1 = patch("cachier.cores.base.asizeof.asizeof", side_effect=Exception("asizeof failed"))
     patch2 = patch("sys.getsizeof", side_effect=Exception("getsizeof failed"))
     with patch1, patch2:
         # Should return True (allow storage) when size can't be determined

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -34,9 +34,7 @@ def test_cleanup_stale_entries(tmp_path):
     add.clear_cache()
     add(1)
     add(2)
-    fname = f".{add.__module__}.{add.__qualname__}".replace("<", "_").replace(
-        ">", "_"
-    )
+    fname = f".{add.__module__}.{add.__qualname__}".replace("<", "_").replace(">", "_")
     cache_path = os.path.join(add.cache_dpath(), fname)
     with open(cache_path, "rb") as fh:
         data = pickle.load(fh)

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -23,10 +23,7 @@ def teardown_function() -> None:
 @pytest.mark.pickle
 def test_cleanup_stale_entries(tmp_path):
     @cachier_dec(
-        cache_dir=tmp_path,
-        stale_after=timedelta(seconds=1),
-        cleanup_stale=True,
-        cleanup_interval=timedelta(seconds=0),
+        cache_dir=tmp_path, stale_after=timedelta(seconds=1), cleanup_stale=True, cleanup_interval=timedelta(seconds=0)
     )
     def add(x):
         return x + 1

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -8,18 +8,12 @@ from cachier.config import get_default_params, set_default_params
 def test_set_default_params_deprecated():
     """Test that set_default_params shows deprecation warning."""
     # Test lines 103-111: deprecation warning
-    with pytest.warns(
-        DeprecationWarning,
-        match="set_default_params.*deprecated.*set_global_params",
-    ):
+    with pytest.warns(DeprecationWarning, match="set_default_params.*deprecated.*set_global_params"):
         set_default_params(stale_after=60)
 
 
 def test_get_default_params_deprecated():
     """Test that get_default_params shows deprecation warning."""
     # Test lines 143-151: deprecation warning
-    with pytest.warns(
-        DeprecationWarning,
-        match="get_default_params.*deprecated.*get_global_params",
-    ):
+    with pytest.warns(DeprecationWarning, match="get_default_params.*deprecated.*get_global_params"):
         assert get_default_params() is not None

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -155,11 +155,7 @@ def test_separate_files_default_param(tmpdir):
 
 
 def test_allow_none_default_param(tmpdir):
-    cachier.set_global_params(
-        allow_none=True,
-        separate_files=True,
-        verbose_cache=True,
-    )
+    cachier.set_global_params(allow_none=True, separate_files=True, verbose_cache=True)
     allow_count = disallow_count = 0
 
     @cachier.cachier(cache_dir=tmpdir)
@@ -258,16 +254,8 @@ def test_wait_for_calc_applies_dynamically(backend, mongetter):
     cachier.set_global_params(wait_for_calc_timeout=2)
     _wait_for_calc_timeout_slow.clear_cache()
     res_queue = queue.Queue()
-    thread1 = threading.Thread(
-        target=_calls_wait_for_calc_timeout_slow,
-        kwargs={"res_queue": res_queue},
-        daemon=True,
-    )
-    thread2 = threading.Thread(
-        target=_calls_wait_for_calc_timeout_slow,
-        kwargs={"res_queue": res_queue},
-        daemon=True,
-    )
+    thread1 = threading.Thread(target=_calls_wait_for_calc_timeout_slow, kwargs={"res_queue": res_queue}, daemon=True)
+    thread2 = threading.Thread(target=_calls_wait_for_calc_timeout_slow, kwargs={"res_queue": res_queue}, daemon=True)
 
     thread1.start()
     thread2.start()

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -313,18 +313,12 @@ def test_deprecated_func_kwargs():
 
     dummy_func.clear_cache()
     assert count == 0
-    with pytest.deprecated_call(
-        match="`verbose_cache` is deprecated and will be removed"
-    ):
+    with pytest.deprecated_call(match="`verbose_cache` is deprecated and will be removed"):
         assert dummy_func(1, verbose_cache=True) == 3
     assert count == 1
-    with pytest.deprecated_call(
-        match="`ignore_cache` is deprecated and will be removed"
-    ):
+    with pytest.deprecated_call(match="`ignore_cache` is deprecated and will be removed"):
         assert dummy_func(1, ignore_cache=True) == 3
     assert count == 2
-    with pytest.deprecated_call(
-        match="`overwrite_cache` is deprecated and will be removed"
-    ):
+    with pytest.deprecated_call(match="`overwrite_cache` is deprecated and will be removed"):
         assert dummy_func(1, overwrite_cache=True) == 3
     assert count == 3

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -53,9 +53,7 @@ def test_set_max_workers():
 
 parametrize_keys = "mongetter,stale_after,separate_files"
 parametrize_values = [
-    pytest.param(
-        _test_mongetter, MONGO_DELTA_LONG, False, marks=pytest.mark.mongo
-    ),
+    pytest.param(_test_mongetter, MONGO_DELTA_LONG, False, marks=pytest.mark.mongo),
     (None, None, False),
     (None, None, True),
 ]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -27,9 +27,7 @@ def test_set_max_workers_command():
     # So the command is registered with a long name
 
     # Test with the actual registered command name
-    result = runner.invoke(
-        cli, ["Limits the number of worker threads used by cachier.", "4"]
-    )
+    result = runner.invoke(cli, ["Limits the number of worker threads used by cachier.", "4"])
     assert result.exit_code == 0
 
     # Test with invalid input (non-integer)
@@ -40,9 +38,7 @@ def test_set_max_workers_command():
     assert result.exit_code != 0
 
     # Test without argument
-    result = runner.invoke(
-        cli, ["Limits the number of worker threads used by cachier."]
-    )
+    result = runner.invoke(cli, ["Limits the number of worker threads used by cachier."])
     assert result.exit_code != 0
 
 

--- a/tests/test_memory_core.py
+++ b/tests/test_memory_core.py
@@ -173,12 +173,8 @@ def test_memory_being_calculated():
     """Testing memory core handling of being calculated scenarios."""
     _takes_time.clear_cache()
     res_queue = queue.Queue()
-    thread1 = threading.Thread(
-        target=_calls_takes_time, kwargs={"res_queue": res_queue}, daemon=True
-    )
-    thread2 = threading.Thread(
-        target=_calls_takes_time, kwargs={"res_queue": res_queue}, daemon=True
-    )
+    thread1 = threading.Thread(target=_calls_takes_time, kwargs={"res_queue": res_queue}, daemon=True)
+    thread2 = threading.Thread(target=_calls_takes_time, kwargs={"res_queue": res_queue}, daemon=True)
     thread1.start()
     sleep(0.5)
     thread2.start()
@@ -249,12 +245,8 @@ def test_clear_being_calculated():
     """Test memory core clear `being calculated` functionality."""
     _takes_time.clear_cache()
     res_queue = queue.Queue()
-    thread1 = threading.Thread(
-        target=_calls_takes_time, kwargs={"res_queue": res_queue}, daemon=True
-    )
-    thread2 = threading.Thread(
-        target=_calls_takes_time, kwargs={"res_queue": res_queue}, daemon=True
-    )
+    thread1 = threading.Thread(target=_calls_takes_time, kwargs={"res_queue": res_queue}, daemon=True)
+    thread2 = threading.Thread(target=_calls_takes_time, kwargs={"res_queue": res_queue}, daemon=True)
     thread1.start()
     _takes_time.clear_being_calculated()
     sleep(0.5)
@@ -298,15 +290,11 @@ def test_callable_hash_param():
     def _hash_func(args, kwargs):
         def _hash(obj):
             if isinstance(obj, pd.core.frame.DataFrame):
-                return hashlib.sha256(
-                    pd.util.hash_pandas_object(obj).values.tobytes()
-                ).hexdigest()
+                return hashlib.sha256(pd.util.hash_pandas_object(obj).values.tobytes()).hexdigest()
             return obj
 
         k_args = tuple(map(_hash, args))
-        k_kwargs = tuple(
-            sorted({k: _hash(v) for k, v in kwargs.items()}.items())
-        )
+        k_kwargs = tuple(sorted({k: _hash(v) for k, v in kwargs.items()}.items()))
         return k_args + k_kwargs
 
     @cachier(backend="memory", hash_func=_hash_func)

--- a/tests/test_memory_core.py
+++ b/tests/test_memory_core.py
@@ -205,16 +205,8 @@ def test_being_calc_next_time():
     _being_calc_next_time(0.13, 0.02)
     sleep(1.1)
     res_queue = queue.Queue()
-    thread1 = threading.Thread(
-        target=_calls_being_calc_next_time,
-        kwargs={"res_queue": res_queue},
-        daemon=True,
-    )
-    thread2 = threading.Thread(
-        target=_calls_being_calc_next_time,
-        kwargs={"res_queue": res_queue},
-        daemon=True,
-    )
+    thread1 = threading.Thread(target=_calls_being_calc_next_time, kwargs={"res_queue": res_queue}, daemon=True)
+    thread2 = threading.Thread(target=_calls_being_calc_next_time, kwargs={"res_queue": res_queue}, daemon=True)
     thread1.start()
     sleep(0.5)
     thread2.start()
@@ -386,21 +378,11 @@ def test_delete_stale_entries():
     core.cache[core._hash_func_key("stale_key")] = stale_entry
 
     # Fresh entry (30 minutes old)
-    fresh_entry = CacheEntry(
-        value="fresh_value",
-        time=now - timedelta(minutes=30),
-        stale=False,
-        _processing=False,
-    )
+    fresh_entry = CacheEntry(value="fresh_value", time=now - timedelta(minutes=30), stale=False, _processing=False)
     core.cache[core._hash_func_key("fresh_key")] = fresh_entry
 
     # Very fresh entry (just created)
-    very_fresh_entry = CacheEntry(
-        value="very_fresh_value",
-        time=now,
-        stale=False,
-        _processing=False,
-    )
+    very_fresh_entry = CacheEntry(value="very_fresh_value", time=now, stale=False, _processing=False)
     core.cache[core._hash_func_key("very_fresh_key")] = very_fresh_entry
 
     # Delete entries older than 1 hour
@@ -441,12 +423,7 @@ def test_delete_stale_entries_all_stale():
 
     # Add only stale entries
     for i in range(5):
-        entry = CacheEntry(
-            value=f"value_{i}",
-            time=old_time,
-            stale=False,
-            _processing=False,
-        )
+        entry = CacheEntry(value=f"value_{i}", time=old_time, stale=False, _processing=False)
         core.cache[core._hash_func_key(f"key_{i}")] = entry
 
     # Delete entries older than 1 day

--- a/tests/test_mongo_core.py
+++ b/tests/test_mongo_core.py
@@ -78,10 +78,7 @@ class CfgKey:
     TEST_VS_DOCKERIZED_MONGO = "TEST_VS_DOCKERIZED_MONGO"
 
 
-CFG = Birch(
-    namespace="cachier",
-    defaults={CfgKey.TEST_VS_DOCKERIZED_MONGO: False},
-)
+CFG = Birch(namespace="cachier", defaults={CfgKey.TEST_VS_DOCKERIZED_MONGO: False})
 
 
 # URI_TEMPLATE = "mongodb://myUser:myPassword@localhost:27017/"

--- a/tests/test_mongo_core.py
+++ b/tests/test_mongo_core.py
@@ -58,9 +58,7 @@ except (ImportError, ModuleNotFoundError):
             """Initialize the mock InMemoryMongoClient."""
             raise ImportError("pymongo_inmemory is not installed!")
 
-    print(
-        "pymongo_inmemory is not installed; in-memory MongoDB tests will fail!"
-    )
+    print("pymongo_inmemory is not installed; in-memory MongoDB tests will fail!")
 
 # local imports
 from cachier import cachier
@@ -100,10 +98,7 @@ def _get_cachier_db_mongo_client():
     return MongoClient(uri)
 
 
-_COLLECTION_NAME = (
-    f"cachier_test_{platform.system()}"
-    f"_{'.'.join(map(str, sys.version_info[:3]))}"
-)
+_COLLECTION_NAME = f"cachier_test_{platform.system()}_{'.'.join(map(str, sys.version_info[:3]))}"
 
 
 def _test_mongetter():
@@ -248,12 +243,8 @@ def test_mongo_being_calculated():
 
     _takes_time.clear_cache()
     res_queue = queue.Queue()
-    thread1 = threading.Thread(
-        target=_calls_takes_time, kwargs={"res_queue": res_queue}, daemon=True
-    )
-    thread2 = threading.Thread(
-        target=_calls_takes_time, kwargs={"res_queue": res_queue}, daemon=True
-    )
+    thread1 = threading.Thread(target=_calls_takes_time, kwargs={"res_queue": res_queue}, daemon=True)
+    thread2 = threading.Thread(target=_calls_takes_time, kwargs={"res_queue": res_queue}, daemon=True)
     thread1.start()
     sleep(1)
     thread2.start()
@@ -330,16 +321,12 @@ def test_stalled_mongo_db_cache():
 @pytest.mark.mongo
 def test_stalled_mong_db_core(monkeypatch):
     def mock_get_entry(self, args, kwargs):
-        return "key", CacheEntry(
-            _processing=True, value=None, time=None, stale=None
-        )
+        return "key", CacheEntry(_processing=True, value=None, time=None, stale=None)
 
     def mock_get_entry_by_key(self, key):
         return "key", None
 
-    monkeypatch.setattr(
-        "cachier.cores.mongo._MongoCore.get_entry", mock_get_entry
-    )
+    monkeypatch.setattr("cachier.cores.mongo._MongoCore.get_entry", mock_get_entry)
     monkeypatch.setattr(
         "cachier.cores.mongo._MongoCore.get_entry_by_key",
         mock_get_entry_by_key,
@@ -360,9 +347,7 @@ def test_stalled_mong_db_core(monkeypatch):
             stale=None,
         )
 
-    monkeypatch.setattr(
-        "cachier.cores.mongo._MongoCore.get_entry", mock_get_entry_2
-    )
+    monkeypatch.setattr("cachier.cores.mongo._MongoCore.get_entry", mock_get_entry_2)
 
     stale_after = datetime.timedelta(seconds=1)
 
@@ -374,9 +359,7 @@ def test_stalled_mong_db_core(monkeypatch):
     res = _stalled_func_2()
     assert res == 2
 
-    @cachier(
-        mongetter=_test_mongetter, stale_after=stale_after, next_time=True
-    )
+    @cachier(mongetter=_test_mongetter, stale_after=stale_after, next_time=True)
     def _stalled_func_3():
         """Testing stalled function."""
         return 3
@@ -390,15 +373,11 @@ def test_callable_hash_param():
     def _hash_func(args, kwargs):
         def _hash(obj):
             if isinstance(obj, pd.core.frame.DataFrame):
-                return hashlib.sha256(
-                    pd.util.hash_pandas_object(obj).values.tobytes()
-                ).hexdigest()
+                return hashlib.sha256(pd.util.hash_pandas_object(obj).values.tobytes()).hexdigest()
             return obj
 
         k_args = tuple(map(_hash, args))
-        k_kwargs = tuple(
-            sorted({k: _hash(v) for k, v in kwargs.items()}.items())
-        )
+        k_kwargs = tuple(sorted({k: _hash(v) for k, v in kwargs.items()}.items()))
         return k_args + k_kwargs
 
     @cachier(mongetter=_test_mongetter, hash_func=_hash_func)

--- a/tests/test_pickle_core.py
+++ b/tests/test_pickle_core.py
@@ -73,9 +73,7 @@ def test_pickle_core(reload, separate_files):
 @pytest.mark.parametrize("separate_files", [True, False])
 def test_pickle_core_keywords(separate_files):
     """Basic Pickle core functionality with keyword arguments."""
-    _takes_2_seconds_decorated = _get_decorated_func(
-        _takes_2_seconds, next_time=False, separate_files=separate_files
-    )
+    _takes_2_seconds_decorated = _get_decorated_func(_takes_2_seconds, next_time=False, separate_files=separate_files)
     _takes_2_seconds_decorated.clear_cache()
     _takes_2_seconds_decorated("a", arg_2="b")
     start = time()
@@ -159,12 +157,8 @@ def _random_num_with_arg(a):
 @pytest.mark.parametrize("separate_files", [True, False])
 def test_overwrite_cache(separate_files):
     """Tests that the overwrite feature works correctly."""
-    _random_num_decorated = _get_decorated_func(
-        _random_num, separate_files=separate_files
-    )
-    _random_num_with_arg_decorated = _get_decorated_func(
-        _random_num_with_arg, separate_files=separate_files
-    )
+    _random_num_decorated = _get_decorated_func(_random_num, separate_files=separate_files)
+    _random_num_with_arg_decorated = _get_decorated_func(_random_num_with_arg, separate_files=separate_files)
     _random_num_decorated.clear_cache()
     int1 = _random_num_decorated()
     int2 = _random_num_decorated()
@@ -190,12 +184,8 @@ def test_overwrite_cache(separate_files):
 @pytest.mark.parametrize("separate_files", [True, False])
 def test_ignore_cache(separate_files):
     """Tests that the ignore_cache feature works correctly."""
-    _random_num_decorated = _get_decorated_func(
-        _random_num, separate_files=separate_files
-    )
-    _random_num_with_arg_decorated = _get_decorated_func(
-        _random_num_with_arg, separate_files=separate_files
-    )
+    _random_num_decorated = _get_decorated_func(_random_num, separate_files=separate_files)
+    _random_num_with_arg_decorated = _get_decorated_func(_random_num_with_arg, separate_files=separate_files)
     _random_num_decorated.clear_cache()
     int1 = _random_num_decorated()
     int2 = _random_num_decorated()
@@ -234,9 +224,7 @@ def _calls_takes_time(takes_time_func, res_queue):
 @pytest.mark.parametrize("separate_files", [True, False])
 def test_pickle_being_calculated(separate_files):
     """Testing pickle core handling of being calculated scenarios."""
-    _takes_time_decorated = _get_decorated_func(
-        _takes_time, separate_files=separate_files
-    )
+    _takes_time_decorated = _get_decorated_func(_takes_time, separate_files=separate_files)
     _takes_time_decorated.clear_cache()
     res_queue = queue.Queue()
     thread1 = threading.Thread(
@@ -327,14 +315,11 @@ def _bad_cache(arg_1, arg_2):
 # _BAD_CACHE_FNAME = '.__main__._bad_cache'
 _BAD_CACHE_FNAME = ".tests.test_pickle_core._bad_cache"
 _BAD_CACHE_FNAME_SEPARATE_FILES = (
-    ".tests.test_pickle_core._bad_cache_"
-    f"{hashlib.sha256(pickle.dumps((0.13, 0.02))).hexdigest()}"
+    f".tests.test_pickle_core._bad_cache_{hashlib.sha256(pickle.dumps((0.13, 0.02))).hexdigest()}"
 )
 EXPANDED_CACHIER_DIR = os.path.expanduser(_global_params.cache_dir)
 _BAD_CACHE_FPATH = os.path.join(EXPANDED_CACHIER_DIR, _BAD_CACHE_FNAME)
-_BAD_CACHE_FPATH_SEPARATE_FILES = os.path.join(
-    EXPANDED_CACHIER_DIR, _BAD_CACHE_FNAME_SEPARATE_FILES
-)
+_BAD_CACHE_FPATH_SEPARATE_FILES = os.path.join(EXPANDED_CACHIER_DIR, _BAD_CACHE_FNAME_SEPARATE_FILES)
 _BAD_CACHE_FPATHS = {
     True: _BAD_CACHE_FPATH_SEPARATE_FILES,
     False: _BAD_CACHE_FPATH,
@@ -355,9 +340,7 @@ def _calls_bad_cache(bad_cache_func, res_queue, trash_cache, separate_files):
 
 def _helper_bad_cache_file(sleep_time: float, separate_files: bool):
     """Test pickle core handling of bad cache files."""
-    _bad_cache_decorated = _get_decorated_func(
-        _bad_cache, separate_files=separate_files
-    )
+    _bad_cache_decorated = _get_decorated_func(_bad_cache, separate_files=separate_files)
     _bad_cache_decorated.clear_cache()
     res_queue = queue.Queue()
     thread1 = threading.Thread(
@@ -418,22 +401,17 @@ def _delete_cache(arg_1, arg_2):
 # _DEL_CACHE_FNAME = '.__main__._delete_cache'
 _DEL_CACHE_FNAME = ".tests.test_pickle_core._delete_cache"
 _DEL_CACHE_FNAME_SEPARATE_FILES = (
-    ".tests.test_pickle_core._delete_cache_"
-    f"{hashlib.sha256(pickle.dumps((0.13, 0.02))).hexdigest()}"
+    f".tests.test_pickle_core._delete_cache_{hashlib.sha256(pickle.dumps((0.13, 0.02))).hexdigest()}"
 )
 _DEL_CACHE_FPATH = os.path.join(EXPANDED_CACHIER_DIR, _DEL_CACHE_FNAME)
-_DEL_CACHE_FPATH_SEPARATE_FILES = os.path.join(
-    EXPANDED_CACHIER_DIR, _DEL_CACHE_FNAME_SEPARATE_FILES
-)
+_DEL_CACHE_FPATH_SEPARATE_FILES = os.path.join(EXPANDED_CACHIER_DIR, _DEL_CACHE_FNAME_SEPARATE_FILES)
 _DEL_CACHE_FPATHS = {
     True: _DEL_CACHE_FPATH_SEPARATE_FILES,
     False: _DEL_CACHE_FPATH,
 }
 
 
-def _calls_delete_cache(
-    del_cache_func, res_queue, del_cache: bool, separate_files: bool
-):
+def _calls_delete_cache(del_cache_func, res_queue, del_cache: bool, separate_files: bool):
     try:
         # print('in')
         res = del_cache_func(0.13, 0.02)
@@ -449,9 +427,7 @@ def _calls_delete_cache(
 
 def _helper_delete_cache_file(sleep_time: float, separate_files: bool):
     """Test pickle core handling of missing cache files."""
-    _delete_cache_decorated = _get_decorated_func(
-        _delete_cache, separate_files=separate_files
-    )
+    _delete_cache_decorated = _get_decorated_func(_delete_cache, separate_files=separate_files)
     _delete_cache_decorated.clear_cache()
     res_queue = queue.Queue()
     thread1 = threading.Thread(
@@ -507,9 +483,7 @@ def test_delete_cache_file(separate_files):
 @pytest.mark.parametrize("separate_files", [False, True])
 def test_clear_being_calculated(separate_files):
     """Test pickle core clear `being calculated` functionality."""
-    _takes_time_decorated = _get_decorated_func(
-        _takes_time, separate_files=separate_files
-    )
+    _takes_time_decorated = _get_decorated_func(_takes_time, separate_files=separate_files)
     _takes_time_decorated.clear_being_calculated()
 
 
@@ -579,15 +553,11 @@ def test_callable_hash_param(separate_files):
     def _hash_func(args, kwargs):
         def _hash(obj):
             if isinstance(obj, pd.core.frame.DataFrame):
-                return hashlib.sha256(
-                    pd.util.hash_pandas_object(obj).values.tobytes()
-                ).hexdigest()
+                return hashlib.sha256(pd.util.hash_pandas_object(obj).values.tobytes()).hexdigest()
             return obj
 
         k_args = tuple(map(_hash, args))
-        k_kwargs = tuple(
-            sorted({k: _hash(v) for k, v in kwargs.items()}.items())
-        )
+        k_kwargs = tuple(sorted({k: _hash(v) for k, v in kwargs.items()}.items()))
         return k_args + k_kwargs
 
     @cachier(hash_func=_hash_func, separate_files=separate_files)
@@ -655,9 +625,7 @@ def test_inotify_instance_limit_reached():
     results = queue.Queue()
 
     # Be more aggressive - try to exhaust the limit
-    N = (
-        min(current_limit * 4, 4096) if current_limit is not None else 4096
-    )  # Try to exceed the limit more aggressively
+    N = min(current_limit * 4, 4096) if current_limit is not None else 4096  # Try to exceed the limit more aggressively
     print(f"Starting {N} threads to test inotify exhaustion")
 
     def call():
@@ -680,20 +648,14 @@ def test_inotify_instance_limit_reached():
     for t in threads:
         t.join()
 
-    print(
-        f"Test completed. Got {len(errors)} errors, {results.qsize()} results"
-    )
+    print(f"Test completed. Got {len(errors)} errors, {results.qsize()} results")
 
     # If any OSError with "inotify instance limit reached" is raised,
     # the test FAILS (expected failure due to the bug)
     if any("inotify instance limit reached" in str(e) for e in errors):
-        print(
-            "FAILURE: Hit inotify instance limit - this indicates the bug "
-            "still exists"
-        )
+        print("FAILURE: Hit inotify instance limit - this indicates the bug still exists")
         raise AssertionError(
-            "inotify instance limit reached error occurred. "
-            f"Got {len(errors)} errors with inotify limit issues."
+            f"inotify instance limit reached error occurred. Got {len(errors)} errors with inotify limit issues."
         )
 
     # If no inotify errors but other errors, fail
@@ -702,10 +664,7 @@ def test_inotify_instance_limit_reached():
         raise AssertionError(f"Unexpected OSErrors: {errors}")
 
     # If no errors at all, the test PASSES (issue is fixed!)
-    print(
-        "SUCCESS: No inotify instance limit errors occurred - the issue "
-        "appears to be fixed!"
-    )
+    print("SUCCESS: No inotify instance limit errors occurred - the issue appears to be fixed!")
     # No need to return - test passes naturally
 
 

--- a/tests/test_pickle_core.py
+++ b/tests/test_pickle_core.py
@@ -97,10 +97,7 @@ def _stale_after_seconds(arg_1, arg_2):
 def test_stale_after(separate_files):
     """Testing the stale_after functionality."""
     _stale_after_seconds_decorated = _get_decorated_func(
-        _stale_after_seconds,
-        stale_after=DELTA,
-        next_time=False,
-        separate_files=separate_files,
+        _stale_after_seconds, stale_after=DELTA, next_time=False, separate_files=separate_files
     )
     _stale_after_seconds_decorated.clear_cache()
     val1 = _stale_after_seconds_decorated(1, 2)
@@ -124,10 +121,7 @@ def _stale_after_next_time(arg_1, arg_2):
 def test_stale_after_next_time(separate_files):
     """Testing the stale_after with next_time functionality."""
     _stale_after_next_time_decorated = _get_decorated_func(
-        _stale_after_next_time,
-        stale_after=DELTA,
-        next_time=True,
-        separate_files=separate_files,
+        _stale_after_next_time, stale_after=DELTA, next_time=True, separate_files=separate_files
     )
     _stale_after_next_time_decorated.clear_cache()
     val1 = _stale_after_next_time_decorated(1, 2)
@@ -229,18 +223,12 @@ def test_pickle_being_calculated(separate_files):
     res_queue = queue.Queue()
     thread1 = threading.Thread(
         target=_calls_takes_time,
-        kwargs={
-            "takes_time_func": _takes_time_decorated,
-            "res_queue": res_queue,
-        },
+        kwargs={"takes_time_func": _takes_time_decorated, "res_queue": res_queue},
         daemon=True,
     )
     thread2 = threading.Thread(
         target=_calls_takes_time,
-        kwargs={
-            "takes_time_func": _takes_time_decorated,
-            "res_queue": res_queue,
-        },
+        kwargs={"takes_time_func": _takes_time_decorated, "res_queue": res_queue},
         daemon=True,
     )
     thread1.start()
@@ -281,18 +269,12 @@ def test_being_calc_next_time(separate_files):
     res_queue = queue.Queue()
     thread1 = threading.Thread(
         target=_calls_being_calc_next_time,
-        kwargs={
-            "being_calc_func": _being_calc_next_time_decorated,
-            "res_queue": res_queue,
-        },
+        kwargs={"being_calc_func": _being_calc_next_time_decorated, "res_queue": res_queue},
         daemon=True,
     )
     thread2 = threading.Thread(
         target=_calls_being_calc_next_time,
-        kwargs={
-            "being_calc_func": _being_calc_next_time_decorated,
-            "res_queue": res_queue,
-        },
+        kwargs={"being_calc_func": _being_calc_next_time_decorated, "res_queue": res_queue},
         daemon=True,
     )
     thread1.start()
@@ -531,10 +513,7 @@ def _takes_2_seconds_custom_dir(arg_1, arg_2):
 def test_pickle_core_custom_cache_dir(separate_files):
     """Basic Pickle core functionality."""
     _takes_2_seconds_custom_dir_decorated = _get_decorated_func(
-        _takes_2_seconds_custom_dir,
-        next_time=False,
-        cache_dir=CUSTOM_DIR,
-        separate_files=separate_files,
+        _takes_2_seconds_custom_dir, next_time=False, cache_dir=CUSTOM_DIR, separate_files=separate_files
     )
     _takes_2_seconds_custom_dir_decorated.clear_cache()
     _takes_2_seconds_custom_dir_decorated("a", "b")
@@ -599,10 +578,7 @@ def test_inotify_instance_limit_reached():
     # Try to get the current inotify limit
     try:
         result = subprocess.run(
-            ["/bin/cat", "/proc/sys/fs/inotify/max_user_instances"],
-            capture_output=True,
-            text=True,
-            timeout=5,
+            ["/bin/cat", "/proc/sys/fs/inotify/max_user_instances"], capture_output=True, text=True, timeout=5
         )
         if result.returncode == 0:
             current_limit = int(result.stdout.strip())

--- a/tests/test_redis_core.py
+++ b/tests/test_redis_core.py
@@ -239,12 +239,7 @@ def test_redis_core_keywords():
 def test_redis_stale_after():
     """Testing Redis core stale_after functionality."""
 
-    @cachier(
-        backend="redis",
-        redis_client=_test_redis_getter,
-        stale_after=timedelta(seconds=3),
-        next_time=False,
-    )
+    @cachier(backend="redis", redis_client=_test_redis_getter, stale_after=timedelta(seconds=3), next_time=False)
     def _stale_after_redis(arg_1, arg_2):
         """Some function."""
         return random() + arg_1 + arg_2
@@ -295,17 +290,9 @@ def test_redis_being_calculated():
     _takes_time.clear_cache()
     res_queue = queue.Queue()
     print("DEBUG: Starting thread1")
-    thread1 = threading.Thread(
-        target=_calls_takes_time_redis,
-        kwargs={"res_queue": res_queue},
-        daemon=True,
-    )
+    thread1 = threading.Thread(target=_calls_takes_time_redis, kwargs={"res_queue": res_queue}, daemon=True)
     print("DEBUG: Starting thread2")
-    thread2 = threading.Thread(
-        target=_calls_takes_time_redis,
-        kwargs={"res_queue": res_queue},
-        daemon=True,
-    )
+    thread2 = threading.Thread(target=_calls_takes_time_redis, kwargs={"res_queue": res_queue}, daemon=True)
     print("DEBUG: Starting thread1")
     thread1.start()
     print("DEBUG: Sleeping 1 second")
@@ -372,11 +359,7 @@ def test_redis_missing_client():
 def test_redis_core_direct():
     """Test Redis core directly."""
     redis_client = _test_redis_getter()
-    core = _RedisCore(
-        hash_func=None,
-        redis_client=redis_client,
-        wait_for_calc_timeout=None,
-    )
+    core = _RedisCore(hash_func=None, redis_client=redis_client, wait_for_calc_timeout=None)
 
     def test_func(x, y):
         return x + y
@@ -429,22 +412,14 @@ def test_redis_import_warning():
     """Test that import warning is raised when redis is not available."""
     ptc = patch("cachier.cores.redis.REDIS_AVAILABLE", False)
     with ptc, pytest.warns(ImportWarning, match="`redis` was not found"):
-        _RedisCore(
-            hash_func=None,
-            redis_client=Mock(),
-            wait_for_calc_timeout=None,
-        )
+        _RedisCore(hash_func=None, redis_client=Mock(), wait_for_calc_timeout=None)
 
 
 @pytest.mark.redis
 def test_missing_redis_client():
     """Test MissingRedisClient exception when redis_client is None."""
     with pytest.raises(MissingRedisClient, match="must specify ``redis_client``"):
-        _RedisCore(
-            hash_func=None,
-            redis_client=None,
-            wait_for_calc_timeout=None,
-        )
+        _RedisCore(hash_func=None, redis_client=None, wait_for_calc_timeout=None)
 
 
 @pytest.mark.redis
@@ -459,11 +434,7 @@ def test_redis_core_exceptions():
     mock_client.keys = MagicMock(side_effect=Exception("Redis keys error"))
     mock_client.delete = MagicMock(side_effect=Exception("Redis delete error"))
 
-    core = _RedisCore(
-        hash_func=None,
-        redis_client=mock_client,
-        wait_for_calc_timeout=10,
-    )
+    core = _RedisCore(hash_func=None, redis_client=mock_client, wait_for_calc_timeout=10)
 
     # Set a mock function
     def mock_func():
@@ -545,11 +516,7 @@ def test_redis_delete_stale_entries():
     """Test delete_stale_entries method with various scenarios."""
     mock_client = MagicMock()
 
-    core = _RedisCore(
-        hash_func=None,
-        redis_client=mock_client,
-        wait_for_calc_timeout=10,
-    )
+    core = _RedisCore(hash_func=None, redis_client=mock_client, wait_for_calc_timeout=10)
 
     # Set a mock function
     def mock_func():
@@ -581,11 +548,7 @@ def test_redis_delete_stale_entries():
     delete_mock_client.delete = MagicMock()
 
     # Create a new core for this test
-    delete_core = _RedisCore(
-        hash_func=None,
-        redis_client=delete_mock_client,
-        wait_for_calc_timeout=10,
-    )
+    delete_core = _RedisCore(hash_func=None, redis_client=delete_mock_client, wait_for_calc_timeout=10)
     delete_core.set_func(mock_func)
 
     # Need to mock _resolve_redis_client to return our mock
@@ -637,11 +600,7 @@ def test_redis_wait_on_entry_calc_no_entry():
     def mock_get_entry_by_key(self, key):
         return key, None
 
-    core = _RedisCore(
-        hash_func=None,
-        redis_client=mock_client,
-        wait_for_calc_timeout=10,
-    )
+    core = _RedisCore(hash_func=None, redis_client=mock_client, wait_for_calc_timeout=10)
 
     # Set a mock function
     def mock_func():
@@ -662,11 +621,7 @@ def test_redis_set_entry_should_not_store():
     """Test set_entry when value should not be stored (None not allowed)."""
     mock_client = MagicMock()
 
-    core = _RedisCore(
-        hash_func=None,
-        redis_client=mock_client,
-        wait_for_calc_timeout=10,
-    )
+    core = _RedisCore(hash_func=None, redis_client=mock_client, wait_for_calc_timeout=10)
 
     # Mock _should_store to return False
     core._should_store = Mock(return_value=False)
@@ -697,11 +652,7 @@ def test_redis_clear_being_calculated_with_pipeline():
     pipeline_mock.hset = MagicMock()
     pipeline_mock.execute = MagicMock()
 
-    core = _RedisCore(
-        hash_func=None,
-        redis_client=pipeline_mock_client,
-        wait_for_calc_timeout=10,
-    )
+    core = _RedisCore(hash_func=None, redis_client=pipeline_mock_client, wait_for_calc_timeout=10)
 
     # Set a mock function
     def mock_func():

--- a/tests/test_redis_core.py
+++ b/tests/test_redis_core.py
@@ -429,22 +429,14 @@ def test_redis_import_warning():
     """Test that import warning is raised when redis is not available."""
     ptc = patch("cachier.cores.redis.REDIS_AVAILABLE", False)
     with ptc, pytest.warns(ImportWarning, match="`redis` was not found"):
-        _RedisCore(
-            hash_func=None,
-            redis_client=Mock(),
-            wait_for_calc_timeout=None,
-        )
+        _RedisCore(hash_func=None, redis_client=Mock(), wait_for_calc_timeout=None)
 
 
 @pytest.mark.redis
 def test_missing_redis_client():
     """Test MissingRedisClient exception when redis_client is None."""
     with pytest.raises(MissingRedisClient, match="must specify ``redis_client``"):
-        _RedisCore(
-            hash_func=None,
-            redis_client=None,
-            wait_for_calc_timeout=None,
-        )
+        _RedisCore(hash_func=None, redis_client=None, wait_for_calc_timeout=None)
 
 
 @pytest.mark.redis
@@ -459,11 +451,7 @@ def test_redis_core_exceptions():
     mock_client.keys = MagicMock(side_effect=Exception("Redis keys error"))
     mock_client.delete = MagicMock(side_effect=Exception("Redis delete error"))
 
-    core = _RedisCore(
-        hash_func=None,
-        redis_client=mock_client,
-        wait_for_calc_timeout=10,
-    )
+    core = _RedisCore(hash_func=None, redis_client=mock_client, wait_for_calc_timeout=10)
 
     # Set a mock function
     def mock_func():
@@ -486,11 +474,7 @@ def test_redis_core_exceptions():
     test_mock_client.hset = MagicMock(side_effect=Exception("Redis write error"))
 
     # Create a new core with this specific mock
-    test_core = _RedisCore(
-        hash_func=None,
-        redis_client=test_mock_client,
-        wait_for_calc_timeout=10,
-    )
+    test_core = _RedisCore(hash_func=None, redis_client=test_mock_client, wait_for_calc_timeout=10)
     test_core.set_func(mock_func)
 
     # Override _should_store to return True
@@ -545,11 +529,7 @@ def test_redis_delete_stale_entries():
     """Test delete_stale_entries method with various scenarios."""
     mock_client = MagicMock()
 
-    core = _RedisCore(
-        hash_func=None,
-        redis_client=mock_client,
-        wait_for_calc_timeout=10,
-    )
+    core = _RedisCore(hash_func=None, redis_client=mock_client, wait_for_calc_timeout=10)
 
     # Set a mock function
     def mock_func():
@@ -581,11 +561,7 @@ def test_redis_delete_stale_entries():
     delete_mock_client.delete = MagicMock()
 
     # Create a new core for this test
-    delete_core = _RedisCore(
-        hash_func=None,
-        redis_client=delete_mock_client,
-        wait_for_calc_timeout=10,
-    )
+    delete_core = _RedisCore(hash_func=None, redis_client=delete_mock_client, wait_for_calc_timeout=10)
     delete_core.set_func(mock_func)
 
     # Need to mock _resolve_redis_client to return our mock
@@ -637,11 +613,7 @@ def test_redis_wait_on_entry_calc_no_entry():
     def mock_get_entry_by_key(self, key):
         return key, None
 
-    core = _RedisCore(
-        hash_func=None,
-        redis_client=mock_client,
-        wait_for_calc_timeout=10,
-    )
+    core = _RedisCore(hash_func=None, redis_client=mock_client, wait_for_calc_timeout=10)
 
     # Set a mock function
     def mock_func():
@@ -662,11 +634,7 @@ def test_redis_set_entry_should_not_store():
     """Test set_entry when value should not be stored (None not allowed)."""
     mock_client = MagicMock()
 
-    core = _RedisCore(
-        hash_func=None,
-        redis_client=mock_client,
-        wait_for_calc_timeout=10,
-    )
+    core = _RedisCore(hash_func=None, redis_client=mock_client, wait_for_calc_timeout=10)
 
     # Mock _should_store to return False
     core._should_store = Mock(return_value=False)
@@ -697,11 +665,7 @@ def test_redis_clear_being_calculated_with_pipeline():
     pipeline_mock.hset = MagicMock()
     pipeline_mock.execute = MagicMock()
 
-    core = _RedisCore(
-        hash_func=None,
-        redis_client=pipeline_mock_client,
-        wait_for_calc_timeout=10,
-    )
+    core = _RedisCore(hash_func=None, redis_client=pipeline_mock_client, wait_for_calc_timeout=10)
 
     # Set a mock function
     def mock_func():

--- a/tests/test_redis_core.py
+++ b/tests/test_redis_core.py
@@ -50,9 +50,7 @@ def _get_test_redis_client():
         port = int(CFG.get(CfgKey.PORT, 6379))
         db = int(CFG.get(CfgKey.DB, 0))
         try:
-            client = redis.Redis(
-                host=host, port=port, db=db, decode_responses=False
-            )
+            client = redis.Redis(host=host, port=port, db=db, decode_responses=False)
             # Test connection
             client.ping()
             return client
@@ -87,14 +85,10 @@ def _test_redis_getter():
                             bytes_result[k.encode("utf-8")] = v.encode("utf-8")
                         else:
                             bytes_result[k.encode("utf-8")] = v
-                    print(
-                        f"DEBUG: hgetall({key}) = {result} -> {bytes_result}"
-                    )
+                    print(f"DEBUG: hgetall({key}) = {result} -> {bytes_result}")
                     return bytes_result
 
-                def hset(
-                    self, key, field=None, value=None, mapping=None, **kwargs
-                ):
+                def hset(self, key, field=None, value=None, mapping=None, **kwargs):
                     if key not in self.data:
                         self.data[key] = {}
 
@@ -158,9 +152,7 @@ def _test_redis_getter():
                 def execute(self):
                     for cmd, key, field, value in self.commands:
                         if cmd == "hset":
-                            self.redis_client.hset(
-                                key, field=field, value=value
-                            )
+                            self.redis_client.hset(key, field=field, value=value)
 
             _test_redis_getter._mock_client = MockRedis()
 
@@ -272,16 +264,10 @@ def _calls_takes_time_redis(res_queue):
     @cachier(backend="redis", redis_client=_test_redis_getter)
     def _takes_time(arg_1, arg_2):
         """Some function."""
-        print(
-            f"DEBUG: _calls_takes_time_redis._takes_time({arg_1}, {arg_2})"
-            " called"
-        )
+        print(f"DEBUG: _calls_takes_time_redis._takes_time({arg_1}, {arg_2}) called")
         sleep(3)
         result = random() + arg_1 + arg_2
-        print(
-            f"DEBUG: _calls_takes_time_redis._takes_time({arg_1}, {arg_2}) "
-            f"returning {result}"
-        )
+        print(f"DEBUG: _calls_takes_time_redis._takes_time({arg_1}, {arg_2}) returning {result}")
         return result
 
     print("DEBUG: _calls_takes_time_redis calling _takes_time(34, 82.3)")
@@ -345,9 +331,7 @@ def test_redis_callable_hash_param():
     def _hash_func(args, kwargs):
         def _hash(obj):
             if isinstance(obj, pd.DataFrame):
-                return hashlib.sha256(
-                    obj.to_string().encode("utf-8")
-                ).hexdigest()
+                return hashlib.sha256(obj.to_string().encode("utf-8")).hexdigest()
             return str(obj)
 
         key_parts = []
@@ -357,14 +341,10 @@ def test_redis_callable_hash_param():
             key_parts.append(f"{key}:{_hash(value)}")
         return hashlib.sha256(":".join(key_parts).encode("utf-8")).hexdigest()
 
-    @cachier(
-        backend="redis", redis_client=_test_redis_getter, hash_func=_hash_func
-    )
+    @cachier(backend="redis", redis_client=_test_redis_getter, hash_func=_hash_func)
     def _params_with_dataframe(*args, **kwargs):
         """Function that can handle DataFrames."""
-        return sum(len(str(arg)) for arg in args) + sum(
-            len(str(val)) for val in kwargs.values()
-        )
+        return sum(len(str(arg)) for arg in args) + sum(len(str(val)) for val in kwargs.values())
 
     df1 = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
     df2 = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
@@ -459,9 +439,7 @@ def test_redis_import_warning():
 @pytest.mark.redis
 def test_missing_redis_client():
     """Test MissingRedisClient exception when redis_client is None."""
-    with pytest.raises(
-        MissingRedisClient, match="must specify ``redis_client``"
-    ):
+    with pytest.raises(MissingRedisClient, match="must specify ``redis_client``"):
         _RedisCore(
             hash_func=None,
             redis_client=None,
@@ -476,9 +454,7 @@ def test_redis_core_exceptions():
     mock_client = MagicMock()
 
     # Configure all methods to raise exceptions
-    mock_client.hgetall = MagicMock(
-        side_effect=Exception("Redis connection error")
-    )
+    mock_client.hgetall = MagicMock(side_effect=Exception("Redis connection error"))
     mock_client.hset = MagicMock(side_effect=Exception("Redis write error"))
     mock_client.keys = MagicMock(side_effect=Exception("Redis keys error"))
     mock_client.delete = MagicMock(side_effect=Exception("Redis delete error"))
@@ -507,9 +483,7 @@ def test_redis_core_exceptions():
     # Test set_entry exception handling
     # Mock the client to ensure it's not callable
     test_mock_client = MagicMock()
-    test_mock_client.hset = MagicMock(
-        side_effect=Exception("Redis write error")
-    )
+    test_mock_client.hset = MagicMock(side_effect=Exception("Redis write error"))
 
     # Create a new core with this specific mock
     test_core = _RedisCore(
@@ -588,9 +562,7 @@ def test_redis_delete_stale_entries():
     delete_mock_client = MagicMock()
 
     # Set up keys method
-    delete_mock_client.keys = MagicMock(
-        return_value=[b"key1", b"key2", b"key3"]
-    )
+    delete_mock_client.keys = MagicMock(return_value=[b"key1", b"key2", b"key3"])
 
     now = datetime.now()
     old_timestamp = (now - timedelta(hours=2)).isoformat()
@@ -718,9 +690,7 @@ def test_redis_clear_being_calculated_with_pipeline():
     pipeline_mock = MagicMock()
 
     # Set up keys to return 3 keys
-    pipeline_mock_client.keys = MagicMock(
-        return_value=[b"key1", b"key2", b"key3"]
-    )
+    pipeline_mock_client.keys = MagicMock(return_value=[b"key1", b"key2", b"key3"])
 
     # Set up pipeline
     pipeline_mock_client.pipeline = MagicMock(return_value=pipeline_mock)

--- a/tests/test_redis_core_exceptions.py
+++ b/tests/test_redis_core_exceptions.py
@@ -16,9 +16,7 @@ class TestRedisCoreExceptions:
     @pytest.fixture
     def core(self, mock_redis):
         """Fixture providing a Redis core instance with mock client."""
-        core = _RedisCore(
-            hash_func=None, redis_client=mock_redis, wait_for_calc_timeout=10
-        )
+        core = _RedisCore(hash_func=None, redis_client=mock_redis, wait_for_calc_timeout=10)
         core.set_func(lambda x: x)  # Set a dummy function
         return core
 
@@ -26,9 +24,7 @@ class TestRedisCoreExceptions:
         """Test _loading_pickle handles exceptions when deserializing bytes."""
         with (
             patch("pickle.loads", side_effect=Exception("Pickle error")),
-            pytest.warns(
-                UserWarning, match="Redis value deserialization failed"
-            ),
+            pytest.warns(UserWarning, match="Redis value deserialization failed"),
         ):
             assert _RedisCore._loading_pickle(b"data") is None
 
@@ -44,9 +40,7 @@ class TestRedisCoreExceptions:
         """Test _loading_pickle decoding failure for str input."""
         with (
             patch("pickle.loads", side_effect=Exception("Pickle error")),
-            pytest.warns(
-                UserWarning, match="Redis value deserialization failed"
-            ),
+            pytest.warns(UserWarning, match="Redis value deserialization failed"),
         ):
             assert _RedisCore._loading_pickle("data") is None
 
@@ -74,9 +68,7 @@ class TestRedisCoreExceptions:
     def test_get_entry_by_key_exceptions_timestamp(self, core, mock_redis):
         """Test get_entry_by_key timestamp decoding exception."""
         mock_redis.hgetall.side_effect = None
-        mock_redis.hgetall.return_value = {
-            b"timestamp": b"\xff"
-        }  # Invalid utf-8
+        mock_redis.hgetall.return_value = {b"timestamp": b"\xff"}  # Invalid utf-8
         with pytest.warns(UserWarning, match="Redis get_entry_by_key failed"):
             core.get_entry_by_key("key")
 
@@ -89,17 +81,13 @@ class TestRedisCoreExceptions:
     def test_mark_entry_being_calculated_exceptions(self, core, mock_redis):
         """Test mark_entry_being_calculated Redis hset exception handling."""
         mock_redis.hset.side_effect = Exception("Redis error")
-        with pytest.warns(
-            UserWarning, match="Redis mark_entry_being_calculated failed"
-        ):
+        with pytest.warns(UserWarning, match="Redis mark_entry_being_calculated failed"):
             core.mark_entry_being_calculated("key")
 
     def test_mark_entry_not_calculated_exceptions(self, core, mock_redis):
         """Test mark_entry_not_calculated Redis hset exception handling."""
         mock_redis.hset.side_effect = Exception("Redis error")
-        with pytest.warns(
-            UserWarning, match="Redis mark_entry_not_calculated failed"
-        ):
+        with pytest.warns(UserWarning, match="Redis mark_entry_not_calculated failed"):
             core.mark_entry_not_calculated("key")
 
     def test_clear_cache_exceptions(self, core, mock_redis):
@@ -111,22 +99,16 @@ class TestRedisCoreExceptions:
     def test_clear_being_calculated_exceptions(self, core, mock_redis):
         """Test clear_being_calculated Redis keys exception handling."""
         mock_redis.keys.side_effect = Exception("Redis error")
-        with pytest.warns(
-            UserWarning, match="Redis clear_being_calculated failed"
-        ):
+        with pytest.warns(UserWarning, match="Redis clear_being_calculated failed"):
             core.clear_being_calculated()
 
     def test_delete_stale_entries_keys_exception(self, core, mock_redis):
         """Test delete_stale_entries Redis keys exception handling."""
         mock_redis.keys.side_effect = Exception("Redis error")
-        with pytest.warns(
-            UserWarning, match="Redis delete_stale_entries failed"
-        ):
+        with pytest.warns(UserWarning, match="Redis delete_stale_entries failed"):
             core.delete_stale_entries(timedelta(seconds=1))
 
-    def test_delete_stale_entries_timestamp_parse_exception(
-        self, core, mock_redis
-    ):
+    def test_delete_stale_entries_timestamp_parse_exception(self, core, mock_redis):
         """Test delete_stale_entries timestamp parsing exception handling."""
         mock_redis.keys.return_value = [b"key1"]
         mock_redis.hget.return_value = b"invalid_timestamp"

--- a/tests/test_sql_core.py
+++ b/tests/test_sql_core.py
@@ -231,9 +231,7 @@ def test_sqlcore_importerror_without_sqlalchemy(monkeypatch):
 
 @pytest.mark.sql
 def test_sqlcore_invalid_sql_engine():
-    with pytest.raises(
-        ValueError, match="sql_engine must be a SQLAlchemy Engine"
-    ):
+    with pytest.raises(ValueError, match="sql_engine must be a SQLAlchemy Engine"):
         _SQLCore(hash_func=None, sql_engine=12345)
 
 


### PR DESCRIPTION
This pull request updates linting and formatting configurations to improve code consistency and streamline tooling. The main changes involve switching formatting plugins, updating pre-commit hooks, and adjusting line length settings.

**Pre-commit configuration updates:**

* Replaced the `mdformat-black` plugin with `mdformat-ruff` in the `mdformat` pre-commit hook to standardize markdown formatting using Ruff conventions.
* Renamed the `ruff` pre-commit hook to `ruff-check` for clarity and consistency.

**Formatting and linting settings:**

* Removed the `[tool.black]` section and its `line-length` setting from `pyproject.toml`, consolidating line length configuration under Ruff.
* Increased the `line-length` setting for Ruff from 79 to 120 characters to allow for longer lines and improve readability.