### PR TITLE
Add NumPy-aware default hashing, regression test, and xxhash benchmark

### DIFF
--- a/scripts/benchmark_numpy_hash.py
+++ b/scripts/benchmark_numpy_hash.py
@@ -1,0 +1,102 @@
+"""Benchmark default Cachier hashing against xxhash for large NumPy arrays."""
+
+from __future__ import annotations
+
+import argparse
+import pickle
+import statistics
+import time
+from typing import Any, Callable, Dict, List
+
+import numpy as np
+
+from cachier.config import _default_hash_func
+
+
+def _xxhash_numpy_hash(args: tuple[Any, ...], kwds: dict[str, Any]) -> str:
+    """Hash call arguments with xxhash, optimized for NumPy arrays.
+
+    Parameters
+    ----------
+    args : tuple[Any, ...]
+        Positional arguments.
+    kwds : dict[str, Any]
+        Keyword arguments.
+
+    Returns
+    -------
+    str
+        xxhash hex digest.
+
+    """
+    import xxhash
+
+    hasher = xxhash.xxh64()
+    hasher.update(b"args")
+    for value in args:
+        if isinstance(value, np.ndarray):
+            hasher.update(value.dtype.str.encode("utf-8"))
+            hasher.update(str(value.shape).encode("utf-8"))
+            hasher.update(value.tobytes(order="C"))
+        else:
+            hasher.update(pickle.dumps(value, protocol=pickle.HIGHEST_PROTOCOL))
+
+    hasher.update(b"kwds")
+    for key, value in sorted(kwds.items()):
+        hasher.update(pickle.dumps(key, protocol=pickle.HIGHEST_PROTOCOL))
+        if isinstance(value, np.ndarray):
+            hasher.update(value.dtype.str.encode("utf-8"))
+            hasher.update(str(value.shape).encode("utf-8"))
+            hasher.update(value.tobytes(order="C"))
+        else:
+            hasher.update(pickle.dumps(value, protocol=pickle.HIGHEST_PROTOCOL))
+
+    return hasher.hexdigest()
+
+
+def _benchmark(hash_func: Callable[[tuple[Any, ...], dict[str, Any]], str], args: tuple[Any, ...], runs: int) -> float:
+    durations: List[float] = []
+    for _ in range(runs):
+        start = time.perf_counter()
+        hash_func(args, {})
+        durations.append(time.perf_counter() - start)
+    return statistics.median(durations)
+
+
+def main() -> None:
+    """Run benchmark comparing cachier default hashing with xxhash."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--elements",
+        type=int,
+        default=10_000_000,
+        help="Number of float64 elements in the benchmark array",
+    )
+    parser.add_argument("--runs", type=int, default=7, help="Number of benchmark runs")
+    parsed = parser.parse_args()
+
+    try:
+        import xxhash  # noqa: F401
+    except ImportError as error:
+        raise SystemExit("Missing dependency: xxhash. Install with `pip install xxhash`.") from error
+
+    array = np.arange(parsed.elements, dtype=np.float64)
+    args = (array,)
+
+    results: Dict[str, float] = {
+        "cachier_default": _benchmark(_default_hash_func, args, parsed.runs),
+        "xxhash_reference": _benchmark(_xxhash_numpy_hash, args, parsed.runs),
+    }
+
+    ratio = results["cachier_default"] / results["xxhash_reference"]
+
+    print(f"Array elements: {parsed.elements:,}")
+    print(f"Array bytes: {array.nbytes:,}")
+    print(f"Runs: {parsed.runs}")
+    print(f"cachier_default median: {results['cachier_default']:.6f}s")
+    print(f"xxhash_reference median: {results['xxhash_reference']:.6f}s")
+    print(f"ratio (cachier_default / xxhash_reference): {ratio:.2f}x")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/cachier/config.py
+++ b/src/cachier/config.py
@@ -29,12 +29,25 @@ def _is_numpy_array(value: Any) -> bool:
 def _hash_numpy_array(hasher: "hashlib._Hash", value: Any) -> None:
     """Update hasher with NumPy array metadata and buffer content.
 
+    The array content is converted to bytes using C-order (row-major) layout
+    to ensure consistent hashing regardless of memory layout. This operation
+    may create a copy if the array is not already C-contiguous (e.g., for
+    transposed arrays, sliced views, or Fortran-ordered arrays), which has
+    performance implications for large arrays.
+
     Parameters
     ----------
     hasher : hashlib._Hash
         The hasher to update.
     value : Any
         A NumPy ndarray instance.
+
+    Notes
+    -----
+    The ``tobytes(order="C")`` call ensures deterministic hash values by
+    normalizing the memory layout, but may incur a memory copy for
+    non-contiguous arrays. For optimal performance with large arrays,
+    consider using C-contiguous arrays when possible.
 
     """
     hasher.update(b"numpy.ndarray")

--- a/src/cachier/config.py
+++ b/src/cachier/config.py
@@ -56,9 +56,7 @@ def _hash_numpy_array(hasher: "hashlib._Hash", value: Any) -> None:
     hasher.update(value.tobytes(order="C"))
 
 
-def _update_hash_for_value(
-    hasher: "hashlib._Hash", value: Any, depth: int = 0, max_depth: int = 100
-) -> None:
+def _update_hash_for_value(hasher: "hashlib._Hash", value: Any, depth: int = 0, max_depth: int = 100) -> None:
     """Update hasher with a stable representation of a Python value.
 
     Parameters

--- a/src/cachier/config.py
+++ b/src/cachier/config.py
@@ -56,7 +56,9 @@ def _hash_numpy_array(hasher: "hashlib._Hash", value: Any) -> None:
     hasher.update(value.tobytes(order="C"))
 
 
-def _update_hash_for_value(hasher: "hashlib._Hash", value: Any) -> None:
+def _update_hash_for_value(
+    hasher: "hashlib._Hash", value: Any, depth: int = 0, max_depth: int = 100
+) -> None:
     """Update hasher with a stable representation of a Python value.
 
     Parameters
@@ -65,8 +67,24 @@ def _update_hash_for_value(hasher: "hashlib._Hash", value: Any) -> None:
         The hasher to update.
     value : Any
         Value to encode.
+    depth : int, optional
+        Current recursion depth (internal use only).
+    max_depth : int, optional
+        Maximum allowed recursion depth to prevent stack overflow.
+
+    Raises
+    ------
+    RecursionError
+        If the recursion depth exceeds max_depth.
 
     """
+    if depth > max_depth:
+        raise RecursionError(
+            f"Maximum recursion depth ({max_depth}) exceeded while hashing nested "
+            f"data structure. Consider flattening your data or using a custom "
+            f"hash_func parameter."
+        )
+
     if _is_numpy_array(value):
         _hash_numpy_array(hasher, value)
         return
@@ -74,20 +92,20 @@ def _update_hash_for_value(hasher: "hashlib._Hash", value: Any) -> None:
     if isinstance(value, tuple):
         hasher.update(b"tuple")
         for item in value:
-            _update_hash_for_value(hasher, item)
+            _update_hash_for_value(hasher, item, depth + 1, max_depth)
         return
 
     if isinstance(value, list):
         hasher.update(b"list")
         for item in value:
-            _update_hash_for_value(hasher, item)
+            _update_hash_for_value(hasher, item, depth + 1, max_depth)
         return
 
     if isinstance(value, dict):
         hasher.update(b"dict")
         for dict_key in sorted(value):
-            _update_hash_for_value(hasher, dict_key)
-            _update_hash_for_value(hasher, value[dict_key])
+            _update_hash_for_value(hasher, dict_key, depth + 1, max_depth)
+            _update_hash_for_value(hasher, value[dict_key], depth + 1, max_depth)
         return
 
     if isinstance(value, (set, frozenset)):

--- a/tests/test_numpy_hash.py
+++ b/tests/test_numpy_hash.py
@@ -1,0 +1,43 @@
+"""Tests for NumPy-aware default hash behavior."""
+
+from datetime import timedelta
+
+import pytest
+
+from cachier import cachier
+
+np = pytest.importorskip("numpy")
+
+
+@pytest.mark.parametrize("backend", ["memory", "pickle"])
+def test_default_hash_func_uses_array_content_for_cache_keys(backend, tmp_path):
+    """Verify equal arrays map to a cache hit and different arrays miss."""
+    call_count = 0
+
+    decorator_kwargs = {"backend": backend, "stale_after": timedelta(seconds=120)}
+    if backend == "pickle":
+        decorator_kwargs["cache_dir"] = tmp_path
+
+    @cachier(**decorator_kwargs)
+    def array_sum(values):
+        nonlocal call_count
+        call_count += 1
+        return int(values.sum())
+
+    arr = np.arange(100_000, dtype=np.int64)
+    arr_copy = arr.copy()
+    changed = arr.copy()
+    changed[-1] = -1
+
+    first = array_sum(arr)
+    assert call_count == 1
+
+    second = array_sum(arr_copy)
+    assert second == first
+    assert call_count == 1
+
+    third = array_sum(changed)
+    assert third != first
+    assert call_count == 2
+
+    array_sum.clear_cache()

--- a/tests/test_numpy_hash.py
+++ b/tests/test_numpy_hash.py
@@ -9,7 +9,13 @@ from cachier import cachier
 np = pytest.importorskip("numpy")
 
 
-@pytest.mark.parametrize("backend", ["memory", "pickle"])
+@pytest.mark.parametrize(
+    "backend",
+    [
+        pytest.param("memory", marks=pytest.mark.memory),
+        pytest.param("pickle", marks=pytest.mark.pickle),
+    ],
+)
 def test_default_hash_func_uses_array_content_for_cache_keys(backend, tmp_path):
     """Verify equal arrays map to a cache hit and different arrays miss."""
     call_count = 0

--- a/tests/test_recursion_depth.py
+++ b/tests/test_recursion_depth.py
@@ -1,0 +1,147 @@
+"""Tests for recursion depth protection in hash function."""
+
+from datetime import timedelta
+
+import pytest
+
+from cachier import cachier
+
+
+@pytest.mark.parametrize(
+    "backend",
+    [
+        pytest.param("memory", marks=pytest.mark.memory),
+        pytest.param("pickle", marks=pytest.mark.pickle),
+    ],
+)
+def test_moderately_nested_structures_work(backend, tmp_path):
+    """Verify that moderately nested structures (< 100 levels) work fine."""
+    call_count = 0
+
+    decorator_kwargs = {"backend": backend, "stale_after": timedelta(seconds=120)}
+    if backend == "pickle":
+        decorator_kwargs["cache_dir"] = tmp_path
+
+    @cachier(**decorator_kwargs)
+    def process_nested(data):
+        nonlocal call_count
+        call_count += 1
+        return "processed"
+
+    # Create a nested structure with 50 levels (well below the 100 limit)
+    nested_list = []
+    current = nested_list
+    for _ in range(50):
+        inner = []
+        current.append(inner)
+        current = inner
+    current.append("leaf")
+
+    # Should work without issues
+    result1 = process_nested(nested_list)
+    assert result1 == "processed"
+    assert call_count == 1
+
+    # Second call should hit cache
+    result2 = process_nested(nested_list)
+    assert result2 == "processed"
+    assert call_count == 1
+
+    process_nested.clear_cache()
+
+
+@pytest.mark.parametrize(
+    "backend",
+    [
+        pytest.param("memory", marks=pytest.mark.memory),
+        pytest.param("pickle", marks=pytest.mark.pickle),
+    ],
+)
+def test_deeply_nested_structures_raise_error(backend, tmp_path):
+    """Verify that deeply nested structures (> 100 levels) raise RecursionError."""
+    decorator_kwargs = {"backend": backend, "stale_after": timedelta(seconds=120)}
+    if backend == "pickle":
+        decorator_kwargs["cache_dir"] = tmp_path
+
+    @cachier(**decorator_kwargs)
+    def process_nested(data):
+        return "processed"
+
+    # Create a nested structure with 150 levels (exceeds the 100 limit)
+    nested_list = []
+    current = nested_list
+    for _ in range(150):
+        inner = []
+        current.append(inner)
+        current = inner
+    current.append("leaf")
+
+    # Should raise RecursionError with a clear message
+    with pytest.raises(
+        RecursionError,
+        match=r"Maximum recursion depth \(100\) exceeded while hashing nested",
+    ):
+        process_nested(nested_list)
+
+
+@pytest.mark.parametrize(
+    "backend",
+    [
+        pytest.param("memory", marks=pytest.mark.memory),
+        pytest.param("pickle", marks=pytest.mark.pickle),
+    ],
+)
+def test_nested_dicts_respect_depth_limit(backend, tmp_path):
+    """Verify that nested dictionaries also respect the depth limit."""
+    decorator_kwargs = {"backend": backend, "stale_after": timedelta(seconds=120)}
+    if backend == "pickle":
+        decorator_kwargs["cache_dir"] = tmp_path
+
+    @cachier(**decorator_kwargs)
+    def process_dict(data):
+        return "processed"
+
+    # Create nested dictionaries beyond the limit
+    nested_dict = {}
+    current = nested_dict
+    for i in range(150):
+        current[f"level_{i}"] = {}
+        current = current[f"level_{i}"]
+    current["leaf"] = "value"
+
+    # Should raise RecursionError
+    with pytest.raises(
+        RecursionError,
+        match=r"Maximum recursion depth \(100\) exceeded while hashing nested",
+    ):
+        process_dict(nested_dict)
+
+
+@pytest.mark.parametrize(
+    "backend",
+    [
+        pytest.param("memory", marks=pytest.mark.memory),
+        pytest.param("pickle", marks=pytest.mark.pickle),
+    ],
+)
+def test_nested_tuples_respect_depth_limit(backend, tmp_path):
+    """Verify that nested tuples also respect the depth limit."""
+    decorator_kwargs = {"backend": backend, "stale_after": timedelta(seconds=120)}
+    if backend == "pickle":
+        decorator_kwargs["cache_dir"] = tmp_path
+
+    @cachier(**decorator_kwargs)
+    def process_tuple(data):
+        return "processed"
+
+    # Create nested tuples beyond the limit
+    nested_tuple = ("leaf",)
+    for _ in range(150):
+        nested_tuple = (nested_tuple,)
+
+    # Should raise RecursionError
+    with pytest.raises(
+        RecursionError,
+        match=r"Maximum recursion depth \(100\) exceeded while hashing nested",
+    ):
+        process_tuple(nested_tuple)


### PR DESCRIPTION
### Motivation
- This will close issue #43 
- Large NumPy ndarrays were being hashed via generic pickle serialization which is inefficient and can be incorrect for array content comparison at scale.  The change ensures array content is hashed deterministically and efficiently without importing NumPy at module import time. 
- Provide a regression test to ensure equal arrays produce cache hits and content-changed arrays produce misses for both `memory` and `pickle` backends. 
- Provide a simple benchmark to compare the current default hasher against an `xxhash`-based reference on very large arrays to validate performance tradeoffs.

### Description
- Implement NumPy-aware hashing helpers in `src/cachier/config.py`: `_is_numpy_array`, `_hash_numpy_array`, and `_update_hash_for_value`, and replace the old pickle+SHA256 approach with an incremental `blake2b`-based default hasher (`_default_hash_func`) that treats ndarray metadata and raw bytes specially. 
- Add `tests/test_numpy_hash.py` which verifies cache hits for identical large arrays and misses when array content changes, parametrized across `memory` and `pickle` backends. 
- Add `scripts/benchmark_numpy_hash.py` which benchmarks the default hasher vs an `xxhash` reference implementation on configurable large NumPy arrays and prints median timings and the ratio. 
- Keep NumPy import lazy/dynamic so missing optional dependencies do not break import-time behavior.

### Testing
- Ran the regression test with `pytest -q tests/test_numpy_hash.py`, result: `2 passed`. 
- Ran linting with `ruff check src/cachier/config.py tests/test_numpy_hash.py scripts/benchmark_numpy_hash.py`, result: all checks passed. 
- Ran static typing with `mypy src/cachier/config.py`, result: no issues. 
- Executed the benchmark `python scripts/benchmark_numpy_hash.py --elements 10000000 --runs 5` after installing `xxhash`, result: `cachier_default median: 0.326273s`, `xxhash_reference median: 0.229056s`, ratio `1.42x` (benchmark succeeded; requires `numpy` and `xxhash` in the environment).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69940c43498c83239a257eb9e1f12328)