### PR TITLE
Prefer git and gh CLI in agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -497,7 +497,9 @@ ______________________________________________________________________
 
 ### c. **More Specific Tips**
 
-- **Use MCP for git operations** (commits, pushes, PRs) instead of CLI.
+- **Use standard git and gh CLI first** for commits, pushes, PRs, and other
+  git/GitHub operations. Use git/GitHub MCP tools only when the CLI has a gap,
+  the CLI is unavailable, or the user explicitly requests MCP usage.
 - **When in doubt, prefer explicit, readable code over cleverness.**
 - **Never use non-ASCII characters or the em dash.**
 - **If stuck, suggest opening a new chat with latest context.**
@@ -543,7 +545,8 @@ ______________________________________________________________________
 - **Workflow:** Issue → Feature branch → GitHub PR
 - **Branch naming:** `feature/<desc>`, `bugfix/<desc>`, etc.
 - **PRs:** Reference relevant issue, link to tests/docs as needed.
-- **Commits:** Use MCP tools, not direct git CLI.
+- **Commits:** Use standard `git` CLI first. Use git MCP tools only when the CLI
+  has a gap, the CLI is unavailable, or the user explicitly requests MCP usage.
 
 ______________________________________________________________________
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -508,7 +508,9 @@ ______________________________________________________________________
 
 ### c. **Claude-Specific Tips**
 
-- **Use MCP for git operations** (commits, pushes, PRs) instead of CLI.
+- **Use standard git and gh CLI first** for commits, pushes, PRs, and other
+  git/GitHub operations. Use git/GitHub MCP tools only when the CLI has a gap,
+  the CLI is unavailable, or the user explicitly requests MCP usage.
 - **When in doubt, prefer explicit, readable code over cleverness.**
 - **Never use non-ASCII characters or the em dash.**
 - **If stuck, suggest opening a new chat with latest context.**
@@ -554,7 +556,8 @@ ______________________________________________________________________
 - **Workflow:** Issue → Feature branch → GitHub PR
 - **Branch naming:** `feature/<desc>`, `bugfix/<desc>`, etc.
 - **PRs:** Reference relevant issue, link to tests/docs as needed.
-- **Commits:** Use MCP tools, not direct git CLI.
+- **Commits:** Use standard `git` CLI first. Use git MCP tools only when the CLI
+  has a gap, the CLI is unavailable, or the user explicitly requests MCP usage.
 
 ______________________________________________________________________
 


### PR DESCRIPTION
## Summary\n- Update agent instructions to prefer standard git and gh CLI for git/GitHub operations.\n- Limit git/GitHub MCP usage to CLI gaps, unavailable CLI, or explicit user request.\n\n## Testing\n- Not run; documentation-only instruction update.