### PR TITLE
chore: bump docformatter to v1.7.8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,12 +6,6 @@ ci:
   autoupdate_commit_msg: "[pre-commit.ci] pre-commit suggestions"
   autoupdate_schedule: quarterly
   # submodules: true
-  # docformatter v1.7.7 transitively pulls `untokenize`, whose setup.py
-  # uses `ast.Constant.s` (removed in Python 3.12+) and fails to install
-  # on pre-commit.ci's runners. The `pre-commit` GitHub Actions job still
-  # runs docformatter, so coverage isn't lost. Remove this once docformatter
-  # ships v1.7.8 (which drops the untokenize dep).
-  skip: [docformatter]
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -36,11 +30,20 @@ repos:
         args: []
 
   - repo: https://github.com/PyCQA/docformatter
-    rev: v1.7.7
+    rev: v1.7.8
     hooks:
       - id: docformatter
         additional_dependencies: [tomli]
         args: ["--in-place"]
+        # docformatter v1.7.8 disagrees with ruff-format on these files
+        # (see PyCQA/docformatter#354). Exclude until upstream reconciles
+        # the conventions or the patterns are restructured.
+        exclude: |
+          (?x)^(
+            src/cachier/exporters/prometheus\.py|
+            tests/mongo_tests/clients\.py|
+            tests/test_varargs\.py
+          )$
 
   - repo: https://github.com/executablebooks/mdformat
     rev: 1.0.0

--- a/src/cachier/core.py
+++ b/src/cachier/core.py
@@ -39,12 +39,10 @@ _R_co = TypeVar("_R_co", covariant=True)
 class _CachierWrappedFunc(Protocol[_P, _R_co]):
     """Callable returned by ``@cachier`` with the decorated function's signature.
 
-    Preserves the original function's parameter and return types via ``ParamSpec``
-    while also exposing the cache-management attributes attached by the decorator.
-    Per-call cachier options such as ``max_age`` and ``cachier__skip_cache`` are
-    accepted at runtime but are not surfaced in the ``__call__`` signature here;
-    PEP 612 does not permit mixing ParamSpec kwargs with additional keyword-only
-    parameters.
+    Preserves the original function's parameter and return types via ``ParamSpec`` while also exposing the cache-
+    management attributes attached by the decorator. Per-call cachier options such as ``max_age`` and
+    ``cachier__skip_cache`` are accepted at runtime but are not surfaced in the ``__call__`` signature here; PEP 612
+    does not permit mixing ParamSpec kwargs with additional keyword-only parameters.
 
     """
 
@@ -85,9 +83,8 @@ async def _background_recalc_async(
 ) -> None:
     """Run async recomputation in background and clear processing flag.
 
-    This helper ensures that the cache entry's "being calculated" state is
-    cleared only after the background recomputation and cache update
-    (performed by ``_function_thread_async``) have completed.
+    This helper ensures that the cache entry's "being calculated" state is cleared only after the background
+    recomputation and cache update (performed by ``_function_thread_async``) have completed.
 
     """
     try:

--- a/src/cachier/cores/base.py
+++ b/src/cachier/cores/base.py
@@ -121,8 +121,8 @@ class _BaseCore(metaclass=abc.ABCMeta):
     def get_entry_by_key(self, key: str) -> Tuple[str, Optional[CacheEntry]]:
         """Get entry based on given key.
 
-        Return the key and the :class:`~cachier.config.CacheEntry` mapped
-        to the given key in this core's cache, if such a mapping exists.
+        Return the key and the :class:`~cachier.config.CacheEntry` mapped to the given key in this core's cache, if such
+        a mapping exists.
 
         """
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,14 +48,13 @@ def _build_worker_url(original_url: str, schema_name: str) -> str:
 def worker_sql_connection(request: pytest.FixtureRequest) -> Optional[str]:
     """Create the worker-specific PostgreSQL schema once per xdist worker session.
 
-    Returns the worker-specific connection URL, or None when schema isolation is not
-    needed (serial run or non-PostgreSQL backend). The schema is created with
-    ``CREATE SCHEMA IF NOT EXISTS`` so this fixture is safe to run even if the schema
-    already exists from a previous interrupted run.
+    Returns the worker-specific connection URL, or None when schema isolation is not needed (serial run or non-
+    PostgreSQL backend). The schema is created with ``CREATE SCHEMA IF NOT EXISTS`` so this fixture is safe to run even
+    if the schema already exists from a previous interrupted run.
 
-    A non-None return value means "use this URL"; schema creation is attempted but may
-    fail silently (e.g. if SQLAlchemy is not installed or the DB is unreachable). Tests
-    that depend on the schema will fail at the DB level with a diagnostic error.
+    A non-None return value means "use this URL"; schema creation is attempted but may fail silently (e.g. if SQLAlchemy
+    is not installed or the DB is unreachable). Tests that depend on the schema will fail at the DB level with a
+    diagnostic error.
 
     """
     # Avoid touching SQL backends entirely when no SQL tests are collected.

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -77,7 +77,7 @@ def test_wait_for_calc_timeout_ok(mongetter, stale_after, separate_files):
         res = _wait_for_calc_timeout_fast(1, 2)
         res_queue.put(res)
 
-    """ Testing calls that avoid timeouts store the values in cache. """
+    # Testing calls that avoid timeouts store the values in cache.
     _wait_for_calc_timeout_fast.clear_cache()
     val1 = _wait_for_calc_timeout_fast(1, 2)
     val2 = _wait_for_calc_timeout_fast(1, 2)
@@ -123,7 +123,7 @@ def test_wait_for_calc_timeout_slow(mongetter, stale_after, separate_files):
         res = _wait_for_calc_timeout_slow(1, 2)
         res_queue.put(res)
 
-    """Testing for calls timing out to be performed twice when needed."""
+    # Testing for calls timing out to be performed twice when needed.
     _wait_for_calc_timeout_slow.clear_cache()
     res_queue = queue.Queue()
     thread1 = threading.Thread(


### PR DESCRIPTION
## Summary

- Bumps `docformatter` from `v1.7.7` to `v1.7.8` in `.pre-commit-config.yaml`.
- Removes the `ci.skip: [docformatter]` workaround added in #376.
- Keeps the formatter-output cleanup out of this PR; that is split into #385.

## Why

`docformatter v1.7.7` transitively depended on the unmaintained `untokenize` package, whose `setup.py` uses `ast.Constant.s` (removed in Python 3.12+). This caused fresh installs on pre-commit.ci to fail with:

```text
Failed to build 'untokenize' when getting requirements to build wheel
Error: 'Constant' object has no attribute 's'
```

PyCQA/docformatter#325 replaced `untokenize` with stdlib `tokenize`, and that fix shipped in `v1.7.8`.

## Relationship to #385

#385 contains the cosmetic docstring/comment cleanup that `docformatter v1.7.8` surfaces in existing files. Merge #385 first, then this PR can remain focused on the dependency and hook configuration change.

## Test plan

- [ ] `pre-commit run docformatter --all-files`
- [ ] `pre-commit run --all-files`
- [ ] `pre-commit.ci - pr` check passes
