### PR TITLE
chore: isolate docformatter cleanup

### DIFF
--- a/src/cachier/core.py
+++ b/src/cachier/core.py
@@ -39,12 +39,10 @@ _R_co = TypeVar("_R_co", covariant=True)
 class _CachierWrappedFunc(Protocol[_P, _R_co]):
     """Callable returned by ``@cachier`` with the decorated function's signature.
 
-    Preserves the original function's parameter and return types via ``ParamSpec``
-    while also exposing the cache-management attributes attached by the decorator.
-    Per-call cachier options such as ``max_age`` and ``cachier__skip_cache`` are
-    accepted at runtime but are not surfaced in the ``__call__`` signature here;
-    PEP 612 does not permit mixing ParamSpec kwargs with additional keyword-only
-    parameters.
+    Preserves the original function's parameter and return types via ``ParamSpec`` while also exposing the cache-
+    management attributes attached by the decorator. Per-call cachier options such as ``max_age`` and
+    ``cachier__skip_cache`` are accepted at runtime but are not surfaced in the ``__call__`` signature here; PEP 612
+    does not permit mixing ParamSpec kwargs with additional keyword-only parameters.
 
     """
 
@@ -85,9 +83,8 @@ async def _background_recalc_async(
 ) -> None:
     """Run async recomputation in background and clear processing flag.
 
-    This helper ensures that the cache entry's "being calculated" state is
-    cleared only after the background recomputation and cache update
-    (performed by ``_function_thread_async``) have completed.
+    This helper ensures that the cache entry's "being calculated" state is cleared only after the background
+    recomputation and cache update (performed by ``_function_thread_async``) have completed.
 
     """
     try:

--- a/src/cachier/cores/base.py
+++ b/src/cachier/cores/base.py
@@ -121,8 +121,8 @@ class _BaseCore(metaclass=abc.ABCMeta):
     def get_entry_by_key(self, key: str) -> Tuple[str, Optional[CacheEntry]]:
         """Get entry based on given key.
 
-        Return the key and the :class:`~cachier.config.CacheEntry` mapped
-        to the given key in this core's cache, if such a mapping exists.
+        Return the key and the :class:`~cachier.config.CacheEntry` mapped to the given key in this core's cache, if such
+        a mapping exists.
 
         """
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,14 +48,13 @@ def _build_worker_url(original_url: str, schema_name: str) -> str:
 def worker_sql_connection(request: pytest.FixtureRequest) -> Optional[str]:
     """Create the worker-specific PostgreSQL schema once per xdist worker session.
 
-    Returns the worker-specific connection URL, or None when schema isolation is not
-    needed (serial run or non-PostgreSQL backend). The schema is created with
-    ``CREATE SCHEMA IF NOT EXISTS`` so this fixture is safe to run even if the schema
-    already exists from a previous interrupted run.
+    Returns the worker-specific connection URL, or None when schema isolation is not needed (serial run or non-
+    PostgreSQL backend). The schema is created with ``CREATE SCHEMA IF NOT EXISTS`` so this fixture is safe to run even
+    if the schema already exists from a previous interrupted run.
 
-    A non-None return value means "use this URL"; schema creation is attempted but may
-    fail silently (e.g. if SQLAlchemy is not installed or the DB is unreachable). Tests
-    that depend on the schema will fail at the DB level with a diagnostic error.
+    A non-None return value means "use this URL"; schema creation is attempted but may fail silently (e.g. if SQLAlchemy
+    is not installed or the DB is unreachable). Tests that depend on the schema will fail at the DB level with a
+    diagnostic error.
 
     """
     # Avoid touching SQL backends entirely when no SQL tests are collected.

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -77,7 +77,7 @@ def test_wait_for_calc_timeout_ok(mongetter, stale_after, separate_files):
         res = _wait_for_calc_timeout_fast(1, 2)
         res_queue.put(res)
 
-    """ Testing calls that avoid timeouts store the values in cache. """
+    # Testing calls that avoid timeouts store the values in cache.
     _wait_for_calc_timeout_fast.clear_cache()
     val1 = _wait_for_calc_timeout_fast(1, 2)
     val2 = _wait_for_calc_timeout_fast(1, 2)
@@ -123,7 +123,7 @@ def test_wait_for_calc_timeout_slow(mongetter, stale_after, separate_files):
         res = _wait_for_calc_timeout_slow(1, 2)
         res_queue.put(res)
 
-    """Testing for calls timing out to be performed twice when needed."""
+    # Testing for calls timing out to be performed twice when needed.
     _wait_for_calc_timeout_slow.clear_cache()
     res_queue = queue.Queue()
     thread1 = threading.Thread(


### PR DESCRIPTION
## Summary

- Rewrap existing docstrings in the files that docformatter v1.7.8 touches.
- Convert two misplaced string literals in tests/test_general.py into ordinary comments.
- Keep the docformatter dependency/configuration bump out of this PR so #381 can stay focused on the hook update.

Closes #384.

## Validation

- [x] `ruff check src/cachier/core.py src/cachier/cores/base.py tests/conftest.py tests/test_general.py`
- [x] `pytest tests/test_general.py -m "not mongo"`
- [ ] `pytest tests/test_general.py`

The full `tests/test_general.py` run passed 32 cases and failed the 4 Mongo-marked cases locally because `pymongo_inmemory` triggers a Python 3.12 `tarfile` `DeprecationWarning` under warnings-as-errors while extracting its embedded MongoDB archive.

## Current CI note

GitHub Actions `pre-commit` is currently failing before reaching this cleanup because the existing mutable `typos` hook rev (`v1`) resolves to `typos==1.47.1`, which is not available on PyPI. `pre-commit.ci - pr` passes on this branch.

## Relationship to #381

This PR carries the cosmetic cleanup that docformatter v1.7.8 would otherwise introduce in #381. #381 is stacked on this branch and now shows only the docformatter hook bump/config change.
