### PR TITLE
ci: pin typos pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
       - id: detect-private-key
 
   - repo: https://github.com/crate-ci/typos
-    rev: v1
+    rev: v1.47.0
     hooks:
       - id: typos
         # empty to do not write fixes


### PR DESCRIPTION
## Summary

- Pin the `crate-ci/typos` pre-commit hook from mutable `v1` to `v1.47.0`.
- Avoid resolving to upstream `v1.47.1`, whose matching PyPI package is not currently available.
- Keep the change limited to `.pre-commit-config.yaml`.

Closes #386.

## Validation

- [x] `pre-commit run typos --all-files`
- [x] `pre-commit run --all-files`

## Context

This unblocks the GitHub Actions `pre-commit` job currently failing on PR #385 before it reaches that PR's cleanup changes.
