### PR TITLE
chore: bump docformatter to v1.7.8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,12 +6,6 @@ ci:
   autoupdate_commit_msg: "[pre-commit.ci] pre-commit suggestions"
   autoupdate_schedule: quarterly
   # submodules: true
-  # docformatter v1.7.7 transitively pulls `untokenize`, whose setup.py
-  # uses `ast.Constant.s` (removed in Python 3.12+) and fails to install
-  # on pre-commit.ci's runners. The `pre-commit` GitHub Actions job still
-  # runs docformatter, so coverage isn't lost. Remove this once docformatter
-  # ships v1.7.8 (which drops the untokenize dep).
-  skip: [docformatter]
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -36,11 +30,23 @@ repos:
         args: []
 
   - repo: https://github.com/PyCQA/docformatter
-    rev: v1.7.7
+    rev: v1.7.8
     hooks:
       - id: docformatter
         additional_dependencies: [tomli]
         args: ["--in-place"]
+        # docformatter v1.7.8 disagrees with ruff-format on these files
+        # (blank lines after docstring-only function bodies, blank lines
+        # between module docstring and first class, and a multi-line
+        # string literal used as an `exec()` argument that docformatter
+        # incorrectly treats as a docstring). Exclude until upstream
+        # reconciles the conventions or the patterns are restructured.
+        exclude: |
+          (?x)^(
+            src/cachier/exporters/prometheus\.py|
+            tests/mongo_tests/clients\.py|
+            tests/test_varargs\.py
+          )$
 
   - repo: https://github.com/executablebooks/mdformat
     rev: 1.0.0


### PR DESCRIPTION
## Summary

- Bumps `docformatter` from `v1.7.7` to `v1.7.8` in `.pre-commit-config.yaml`.
- Removes the `ci.skip: [docformatter]` workaround added in #376.
- Adds a small `exclude:` block for 3 files where v1.7.8 disagrees with `ruff-format` (see PyCQA/docformatter#354).

Reopens the intent of #381 over an up-to-date `master`. The cosmetic docstring cleanup that #381 originally bundled is already on `master` via #385, so this PR is now scoped solely to the dependency + hook configuration change.

## Why

`docformatter v1.7.7` transitively depended on the unmaintained `untokenize` package, whose `setup.py` uses `ast.Constant.s` (removed in Python 3.12+). This caused fresh installs on pre-commit.ci to fail with:

```
Failed to build 'untokenize' when getting requirements to build wheel
Error: 'Constant' object has no attribute 's'
```

PyCQA/docformatter#325 replaced `untokenize` with stdlib `tokenize`, and that fix shipped in v1.7.8.

## On the exclude block

v1.7.8 also tightened a few docstring decisions that conflict with `ruff-format` on three files:

- `src/cachier/exporters/prometheus.py` — blank lines after docstring-only function bodies
- `tests/mongo_tests/clients.py` — blank lines between module docstring and first class
- `tests/test_varargs.py` — multi-line string literals used as `exec()` arguments that docformatter mistakes for docstrings

These are excluded via a regex `exclude:` block until upstream (PyCQA/docformatter#354) reconciles the conventions, or the local patterns are restructured. Happy to drop the exclude and restructure the patterns in a follow-up if preferred.

## Test plan

- [x] `pre-commit run docformatter --all-files` passes locally
- [ ] `pre-commit.ci - pr` check passes

## Notes

- Supersedes #381 (closed). cc @shaypal5 @Borda
- @Borda's review pointer to PyCQA/docformatter#354 is now reflected in the commit message and PR body.